### PR TITLE
Chore/epa 92 permissions storage render

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,5 +1,9 @@
 # 📝 Backlog Jira Sync
 
+- [EPA-92] Configurer la permission de storage sur render (Assigné à: Mialisoa Lisa Rasoanirina)
+  Branche: `chore/EPA-92-permissions-storage-render`
+  Commit: `EPA-92: chore, mise à jour de dockerfile pour la permission storage, ajout de render-build-sh`    
+
 - [EPA-88] Fix php-stan, pint et security-check (Assigné à: Mialisoa Lisa Rasoanirina)
   Branche: `fix/EPA-88-fix-stan-pint-securitycheck`
   Commit: `EPA-88: run et fix pint, phpStan security check, fix test`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,24 @@
 # Étape de construction
 FROM php:8.4.2-fpm as builder
 
-# 1. Créez d'abord les répertoires avec les bonnes permissions
-RUN mkdir -p /var/www/bootstrap/cache /var/www/storage/framework/{sessions,views,cache} \
-    && chown -R www-data:www-data /var/www \
-    && chmod -R 775 /var/www/bootstrap/cache /var/www/storage
-
-# 2. Installer les dépendances système
+# 1. Installer les dépendances système
 RUN apt-get update && apt-get install -y \
     git curl libpng-dev libonig-dev libxml2-dev libpq-dev zip unzip \
     && docker-php-ext-install pdo pdo_pgsql mbstring exif pcntl bcmath gd \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-
-# 3. Installer Composer (en tant qu'utilisateur non-root)
+# 2. Installer Composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
-# 4. Configurer l'application
+# 3. Configurer l'application
 WORKDIR /var/www
 COPY . .
+
+# 4. Créer les répertoires avec les bonnes permissions AVANT l'installation des dépendances
+RUN mkdir -p storage/framework/{sessions,views,cache} bootstrap/cache \
+    && chown -R www-data:www-data /var/www \
+    && chmod -R 775 storage bootstrap/cache
 
 # 5. Installer les dépendances avec le bon utilisateur
 USER www-data
@@ -34,14 +33,18 @@ FROM webdevops/php:8.2-alpine
 
 # Copier depuis le builder
 COPY --from=builder --chown=www-data:www-data /var/www /var/www
-COPY --from=builder /usr/local/bin/composer /usr/local/bin/composer
 
 # Variables d'environnement
 ENV PORT=10000
 EXPOSE $PORT
 
-# Configurez le répertoire de travail une seconde fois avant CMD
+# Configurer les permissions finales
+RUN chown -R www-data:www-data /var/www \
+    && chmod -R 775 /var/www/storage /var/www/bootstrap/cache
+
 WORKDIR /var/www
 
-# Commande optimisée pour Render
-CMD ["sh", "-c", "php artisan optimize && php artisan serve --host=0.0.0.0 --port=${PORT}"]
+# Commande optimisée avec configuration des permissions
+CMD sh -c "php artisan storage:link && \
+           php artisan optimize && \
+           php artisan serve --host=0.0.0.0 --port=${PORT}"

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -170,9 +170,9 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->bind(SocialPostCreateService::class, function ($app) {
             return new SocialPostCreateService(
-                $app->make(SocialPostRepository::class),
-                $app->make(CampaignRepositoryInterface::class),
+                $app->make(SocialPostRepositoryInterface::class),
                 $app->make(SocialPostGeneratorService::class),
+                $app->make(SocialPostValidationService::class)
             );
         });
 

--- a/render-build.sh
+++ b/render-build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Script de build pour Render
+
+echo " Configuration des permissions..."
+chmod -R 775 storage bootstrap/cache
+chown -R www-data:www-data storage bootstrap/cache
+
+echo "Installation des dépendances..."
+composer install --no-dev --optimize-autoloader
+
+echo " Nettoyage du cache..."
+php artisan cache:clear
+php artisan config:cache
+
+echo " Création du lien de stockage..."
+php artisan storage:link
+
+echo "Build terminé!"


### PR DESCRIPTION
Cette PR résout les problèmes de permissions du dossier storage sur Render en:
- Ajout de render-build.sh - Script de build qui configure les permissions nécessaires pour les dossiers storage et bootstrap/cache
- Optimisation du Dockerfile - Réorganisation des commandes pour garantir la bonne configuration des permissions avant l'installation des dépendances