### PR TITLE
EPA-91: Ajout de document de spéficition openAPI

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,4 +1,8 @@
 # 📝 Backlog Jira Sync
+- [EPA-103] Création de document OpenApi Swagger (Assigné à: Mialisoa Lisa Rasoanirina)
+  Branche: `feature/EPA-103-openApi`
+  Commit: `EPA-91: Ajout de document de spéficition openAPI`
+
 - [EPA-91] Mise à jour des contenus Landing Page
   Branche: `EPA-91-landing-page-edit-content`
   Commit: `EPA-91: Refactor LandingPage controllers and service for improved validation and error handling`

--- a/app/DTOs/CampaignTemplate/CampaignTemplate.php
+++ b/app/DTOs/CampaignTemplate/CampaignTemplate.php
@@ -2,7 +2,7 @@
 
 namespace App\DTOs\CampaignTemplate;
 
-class CampaignTemplateDto
+class CampaignTemplate
 {
     public function __construct(
         public ?int $id,

--- a/app/Http/Requests/Campaign/CreateCampaignRequest.php
+++ b/app/Http/Requests/Campaign/CreateCampaignRequest.php
@@ -30,7 +30,7 @@ class CreateCampaignRequest extends FormRequest
     {
         return [
             'name.required' => 'Le nom de la campaign est obligatoire.',
-            'description.required' => 'La description de la campaign kkkkkk est obligatoire.',
+            'description.required' => 'La description de la campaign est obligatoire.',
             'description.max' => 'La description ne peut pas dépasser 1000 caractères.',
             'type_campaign_id.exists' => 'Type de campaign invalide.',
 

--- a/app/OpenApi/Controllers/Auth/LoginControllerDoc.php
+++ b/app/OpenApi/Controllers/Auth/LoginControllerDoc.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\OpenApi\Controllers\Auth;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/auth/login",
+ *     summary="Connexion utilisateur",
+ *     description="Authentifie un utilisateur et retourne un token JWT",
+ *     tags={"Authentication"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données de connexion",
+ *
+ *         @OA\JsonContent(
+ *             required={"email", "password"},
+ *
+ *             @OA\Property(property="email", type="string", format="email", example="john.doe@example.com"),
+ *             @OA\Property(property="password", type="string", format="password", example="Password123!")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Connexion réussie",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="success",
+ *                 type="boolean",
+ *                 example=true
+ *             ),
+ *             @OA\Property(
+ *                 property="message",
+ *                 type="string",
+ *                 example="Connexion réussie."
+ *             ),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="user",
+ *                     type="object",
+ *                     ref="#/components/schemas/User"
+ *                 ),
+ *                 @OA\Property(
+ *                     property="token",
+ *                     type="string",
+ *                     example="1|a1b2c3d4e5f6g7h8i9j0..."
+ *                 ),
+ *                 @OA\Property(
+ *                     property="token_type",
+ *                     type="string",
+ *                     example="Bearer"
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Email ou mot de passe invalide",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Email ou mot de passe invalide"),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 nullable=true
+ *             )
+ *         )
+ *     )
+ * )
+ */
+class LoginControllerDoc {}

--- a/app/OpenApi/Controllers/Auth/LogoutControllerDoc.php
+++ b/app/OpenApi/Controllers/Auth/LogoutControllerDoc.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\OpenApi\Controllers\Auth;
+
+/**
+ * @OA\Post(
+ *     path="/api/auth/logout",
+ *     summary="Déconnexion utilisateur",
+ *     tags={"Authentication"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Déconnexion réussie",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Déconnexion réussie.")
+ *         )
+ *     )
+ * )
+ */
+class LogoutControllerDoc {}

--- a/app/OpenApi/Controllers/Auth/MeControllerDoc.php
+++ b/app/OpenApi/Controllers/Auth/MeControllerDoc.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\OpenApi\Controllers\Auth;
+
+/**
+ * @OA\Get(
+ *     path="/api/auth/me",
+ *     summary="Récupérer les informations de l'utilisateur connecté",
+ *     tags={"Authentication"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Informations utilisateur",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", type="object")
+ *         )
+ *     )
+ * )
+ */
+class MeControllerDoc {}

--- a/app/OpenApi/Controllers/Auth/RefreshTokenControllerDoc.php
+++ b/app/OpenApi/Controllers/Auth/RefreshTokenControllerDoc.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\OpenApi\Controllers\Auth;
+
+/**
+ * @OA\Post(
+ *     path="/api/auth/refresh-token",
+ *     summary="Rafraîchir le token",
+ *     tags={"Authentication"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Token rafraîchi",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Token rafraîchi"),
+ *             @OA\Property(property="data", type="object")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=500, description="Erreur serveur", @OA\JsonContent(ref="#/components/schemas/Error500"))
+ * )
+ */
+class RefreshTokenControllerDoc {}

--- a/app/OpenApi/Controllers/Auth/RegisterControllerDoc.php
+++ b/app/OpenApi/Controllers/Auth/RegisterControllerDoc.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\OpenApi\Controllers\Auth;
+
+/**
+ * @OA\Post(
+ *     path="/api/auth/register",
+ *     summary="Inscription utilisateur",
+ *     tags={"Authentication"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"name","email","password","password_confirmation"},
+ *
+ *             @OA\Property(property="name", type="string", example="John Doe"),
+ *             @OA\Property(property="email", type="string", format="email", example="john.doe@example.com"),
+ *             @OA\Property(property="password", type="string", format="password", example="Password123!"),
+ *             @OA\Property(property="password_confirmation", type="string", format="password", example="Password123!")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Inscription réussie",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Inscription réussie"),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="user", ref="#/components/schemas/User"),
+ *                 @OA\Property(property="token", type="string", example="1|a1b2c3d4e5f6..."),
+ *                 @OA\Property(property="token_type", type="string", example="Bearer")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error422")
+ *     ),
+ *
+ *     @OA\Response(response=500, description="Erreur serveur", @OA\JsonContent(ref="#/components/schemas/Error500"))
+ * )
+ */
+class RegisterControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignByTypeControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignByTypeControllerDoc.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaigns/type/{typeId}",
+ *     summary="Lister les campagnes par type",
+ *     description="Retourne les campagnes correspondant à un type spécifique. Les campagnes sont filtrées selon les permissions de l'utilisateur connecté.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="typeId",
+ *         in="path",
+ *         required=true,
+ *         description="ID du type de campagne",
+ *
+ *         @OA\Schema(type="integer", example=2)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Campagnes récupérées avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=3)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Type de campagne introuvable",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignByTypeControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignCriteriaControllerDoc.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaigns/search",
+ *     summary="Lister les campagnes selon des critères",
+ *     description="Retourne les campagnes filtrées selon les critères passés en query params.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="status",
+ *         in="query",
+ *         required=false,
+ *         description="Filtrer par statut de campagne",
+ *
+ *         @OA\Schema(type="string", example="active")
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="type_campaign_id",
+ *         in="query",
+ *         required=false,
+ *         description="Filtrer par type de campagne",
+ *
+ *         @OA\Schema(type="integer", example=2)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="is_published",
+ *         in="query",
+ *         required=false,
+ *         description="Filtrer par publication",
+ *
+ *         @OA\Schema(type="boolean", example=true)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Campagnes récupérées avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=5)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "La requête est invalide ou mal formée",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de consulter ces campagnes",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur de serveur est survenue"
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class CampaignCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignDestroyControllerDoc.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Delete(
+ *     path="/api/campaigns/{id}",
+ *     summary="Supprimer une campagne",
+ *     description="Supprime une campagne existante appartenant à l’utilisateur connecté (ou accessible par un admin).",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID de la campagne à supprimer",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Campagne supprimée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "La requête est invalide",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignGenerateNameControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignGenerateNameControllerDoc.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaigns/generate-name",
+ *     summary="Générer une campagne depuis une description",
+ *     description="Crée une campagne basée sur la description fournie et retourne la campagne générée.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données pour générer la campagne",
+ *
+ *         @OA\JsonContent(
+ *             required={"description","type_campaign_id","user_id"},
+ *
+ *             @OA\Property(property="description", type="string", example="Nouvelle campagne marketing"),
+ *             @OA\Property(property="type_campaign_id", type="integer", example=2),
+ *             @OA\Property(property="user_id", type="integer", example=10)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Campagne générée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(
+ *                 property="campaign",
+ *                 type="object",
+ *                 description="Campagne générée",
+ *                 @OA\Property(property="id", type="integer", example=15),
+ *                 @OA\Property(property="name", type="string", example="Campagne générée automatiquement"),
+ *                 @OA\Property(property="description", type="string", example="Nouvelle campagne marketing"),
+ *                 @OA\Property(property="type_campaign_id", type="integer", example=2),
+ *                 @OA\Property(property="user_id", type="integer", example=10),
+ *                 @OA\Property(property="status", type="string", example="created"),
+ *                 @OA\Property(property="is_published", type="boolean", example=false)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "La requête est invalide ou mal formée",
+ *                 "errors": {
+ *                     "description": {"Le champ description est obligatoire."},
+ *                     "type_campaign_id": {"Type de campagne invalide."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides.",
+ *                 "errors": {
+ *                     "description": {"Le champ description est obligatoire."},
+ *                     "user_id": {"Utilisateur inexistant."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignGenerateNameControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignIndexControllerDoc.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaigns",
+ *     summary="Lister les campagnes",
+ *     description="Retourne toutes les campagnes (si admin) ou celles de l’utilisateur connecté.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des campagnes récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=5)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Non autorisé à accéder à cette ressource",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignIndexControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignShowControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignShowControllerDoc.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaigns/{id}",
+ *     summary="Afficher une campagne",
+ *     description="Retourne les détails d'une campagne spécifique par son ID.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de la campagne",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails de la campagne récupérés avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Non autorisé à accéder à cette ressource",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Campagne introuvable",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignShowControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignStoreByTemplateControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignStoreByTemplateControllerDoc.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaigns/template",
+ *     summary="Créer une campagne à partir d'un template",
+ *     description="Crée une nouvelle campagne en utilisant un template existant et crée éventuellement des social posts associés.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données nécessaires pour créer la campagne avec template",
+ *
+ *         @OA\JsonContent(
+ *             required={"name", "description", "type_campaign_id", "template_id"},
+ *
+ *             @OA\Property(property="name", type="string", maxLength=255, example="Nouvelle campagne avec template"),
+ *             @OA\Property(property="description", type="string", maxLength=1000, example="Description complète de la campagne"),
+ *             @OA\Property(property="type_campaign_id", type="integer", example=2),
+ *             @OA\Property(property="template_id", type="integer", example=5),
+ *             @OA\Property(property="status", type="string", nullable=true, example="created"),
+ *             @OA\Property(property="is_published", type="boolean", example=false),
+ *             @OA\Property(
+ *                 property="social_posts",
+ *                 type="array",
+ *                 description="Liste optionnelle de posts sociaux à créer avec la campagne",
+ *
+ *                 @OA\Items(
+ *                     type="object",
+ *
+ *                     @OA\Property(property="content", type="string", example="Contenu du post social"),
+ *                     @OA\Property(property="social", type="object",
+ *                         @OA\Property(property="id", type="integer", example=1)
+ *                     )
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Campagne créée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides",
+ *                 "errors": {
+ *                     "name": {"Le nom de la campagne est obligatoire."},
+ *                     "description": {"La description est obligatoire."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignStoreByTemplateControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignStoreControllerDoc.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaigns",
+ *     summary="Créer une campagne",
+ *     description="Crée une nouvelle campagne pour l’utilisateur connecté.",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données nécessaires pour créer une campagne",
+ *
+ *         @OA\JsonContent(
+ *             required={"name", "description", "type_campaign_id"},
+ *
+ *             @OA\Property(property="name", type="string", maxLength=255, example="Nouvelle campagne marketing"),
+ *             @OA\Property(property="description", type="string", maxLength=1000, example="Description complète de la campagne"),
+ *             @OA\Property(property="type_campaign_id", type="integer", example=2),
+ *             @OA\Property(property="status", type="string", nullable=true, example="created"),
+ *             @OA\Property(property="is_published", type="boolean", example=false),
+ *             @OA\Property(
+ *                 property="social_posts",
+ *                 type="array",
+ *                 description="Liste optionnelle de posts associés",
+ *
+ *                 @OA\Items(type="string", example="Contenu d’un post social")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Campagne créée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides.",
+ *                 "errors": {
+ *                     "name": {"Le nom de la campagne est obligatoire."},
+ *                     "description": {"La description de la campagne est obligatoire."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignStoreControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignUpdateControllerDoc.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Put(
+ *     path="/api/campaigns/{id}",
+ *     summary="Mettre à jour une campagne",
+ *     description="Met à jour une campagne existante appartenant à l’utilisateur connecté (ou accessible par un admin).",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID de la campagne à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données à mettre à jour pour la campagne",
+ *
+ *         @OA\JsonContent(
+ *             required={"name", "description", "type_campaign_id"},
+ *
+ *             @OA\Property(property="name", type="string", maxLength=255, example="Nom mis à jour de la campagne"),
+ *             @OA\Property(property="description", type="string", maxLength=1000, example="Nouvelle description de la campagne"),
+ *             @OA\Property(property="type_campaign_id", type="integer", example=2),
+ *             @OA\Property(property="status", type="string", nullable=true, example="active"),
+ *             @OA\Property(property="is_published", type="boolean", example=true),
+ *             @OA\Property(
+ *                 property="social_posts",
+ *                 type="array",
+ *                 description="Liste optionnelle de posts associés",
+ *
+ *                 @OA\Items(type="string", example="Contenu modifié d’un post social")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Campagne mise à jour avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *      response=403,
+ *      description="Accès interdit",
+ *
+ *      @OA\JsonContent(
+ *          ref="#/components/schemas/Error403"
+ *      )
+ *  ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Campagne introuvable",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *          example={
+ *              "success": false,
+ *              "message": "Les données fournies sont invalides.",
+ *              "errors": {
+ *              "name": {"Le nom de la campaign est obligatoire."},
+ *              "description": {"La description de la campagne ne dépasse pas 1000 caractères"}
+ *          }
+ *      })
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500"
+ *     )
+ *   )
+ * )
+ */
+class CampaignUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/CampaignUserControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/CampaignUserControllerDoc.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaigns/user/{userId}",
+ *     summary="Récupérer les campagnes d'un utilisateur",
+ *     description="Retourne la liste des campagnes appartenant à un utilisateur spécifique",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="userId",
+ *         in="path",
+ *         required=true,
+ *         description="ID de l'utilisateur",
+ *
+ *         @OA\Schema(type="integer", example=10)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Campagnes récupérées avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=5)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Utilisateur non trouvé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignUserControllerDoc {}

--- a/app/OpenApi/Controllers/Campaign/PopularCampaignControllerDoc.php
+++ b/app/OpenApi/Controllers/Campaign/PopularCampaignControllerDoc.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\OpenApi\Controllers\Campaign;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaigns/popular/content",
+ *     summary="Récupérer les campagnes populaires",
+ *     description="Retourne la liste des campagnes populaires avec leurs statistiques",
+ *     tags={"Campaigns"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des campagnes populaires récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/PopularCampaignResourceSchema")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="totals",
+ *                 type="object",
+ *                 @OA\Property(property="total_views", type="integer", example=5000),
+ *                 @OA\Property(property="total_likes", type="integer", example=350)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class PopularCampaignControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesCriteriaControllerDoc.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignFeatures;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-features/search",
+ *     summary="Récupérer les CampaignFeatures selon des critères",
+ *     description="Retourne la liste des CampaignFeatures filtrée par les critères passés en query. Les utilisateurs non admin ne voient que leurs propres CampaignFeatures.",
+ *     tags={"CampaignFeatures"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID de campagne",
+ *
+ *         @OA\Schema(type="integer", example=10)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="feature_id",
+ *         in="query",
+ *         description="Filtrer par ID de feature",
+ *
+ *         @OA\Schema(type="integer", example=3)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des CampaignFeatures récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignFeaturesResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignFeaturesCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesDestroyControllerDoc.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignFeatures;
+
+/**
+ * @OA\Delete(
+ *     path="/api/campaign-features/{id}",
+ *     summary="Supprimer une CampaignFeature",
+ *     description="Supprime une CampaignFeature par son ID. Seul l'utilisateur autorisé peut effectuer cette action.",
+ *     tags={"CampaignFeatures"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID de la CampaignFeature à supprimer",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="CampaignFeature supprimée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="CampaignFeature introuvable",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignFeaturesDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesIndexControllerDoc.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignFeatures;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-features",
+ *     operationId="getCampaignFeatures",
+ *     summary="Lister toutes les CampaignFeatures",
+ *     description="Retourne la liste complète des CampaignFeatures. Les utilisateurs non admin ne voient que leurs propres CampaignFeatures.",
+ *     tags={"CampaignFeatures"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID de campagne",
+ *
+ *         @OA\Schema(type="integer", example=10)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="feature_id",
+ *         in="query",
+ *         description="Filtrer par ID de feature",
+ *
+ *         @OA\Schema(type="integer", example=3)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des CampaignFeatures récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignFeaturesResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignFeaturesIndexControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesShowControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesShowControllerDoc.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignFeatures;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-features/{id}",
+ *     summary="Afficher une CampaignFeature",
+ *     description="Retourne les détails d'une CampaignFeature spécifique par son ID.",
+ *     tags={"CampaignFeatures"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID de la CampaignFeature à récupérer",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="CampaignFeature récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignFeaturesResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="CampaignFeature introuvable",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignFeaturesShowControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesStoreControllerDoc.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignFeatures;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaign-features",
+ *     operationId="createCampaignFeature",
+ *     summary="Créer une nouvelle CampaignFeature",
+ *     description="Crée une nouvelle CampaignFeature pour une campagne spécifique.",
+ *     tags={"CampaignFeatures"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données nécessaires pour créer une CampaignFeature",
+ *
+ *         @OA\JsonContent(
+ *             required={"campaign_id", "feature_id"},
+ *
+ *             @OA\Property(property="campaign_id", type="integer", example=10),
+ *             @OA\Property(property="feature_id", type="integer", example=3)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="CampaignFeature créée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignFeaturesResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides",
+ *                 "errors": {
+ *                     "campaign_id": {"La campagne spécifiée est introuvable."},
+ *                     "feature_id": {"La fonctionnalité sélectionnée est invalide."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignFeaturesStoreControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignFeatures/CampaignFeaturesUpdateControllerDoc.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignFeatures;
+
+/**
+ * @OA\Put(
+ *     path="/api/campaign-features/{id}",
+ *     summary="Mettre à jour une CampaignFeature",
+ *     description="Met à jour les informations d'une CampaignFeature existante.",
+ *     tags={"CampaignFeatures"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID de la CampaignFeature à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données à mettre à jour pour la CampaignFeature",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="campaign_id", type="integer", example=10),
+ *             @OA\Property(property="feature_id", type="integer", example=3)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="CampaignFeature mise à jour avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignFeaturesResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignFeaturesUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionCriteriaControllerDoc.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-interactions/search",
+ *     summary="Lister les interactions d'une campagne selon des critères",
+ *     description="Récupère une liste des interactions (vues, likes, partages, etc.) filtrées par critères fournis en query params.",
+ *     tags={"Campaign Interactions"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par identifiant de la campagne",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par identifiant de l’utilisateur",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=45)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="type",
+ *         in="query",
+ *         description="Type d’interaction (view, like, share…)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="string", example="like")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des interactions trouvées selon les critères",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignInteractionResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total_interactions", type="integer", example=50),
+ *                 @OA\Property(property="total_views", type="integer", example=1200),
+ *                 @OA\Property(property="total_likes", type="integer", example=300),
+ *                 @OA\Property(property="total_shares", type="integer", example=75)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error400"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error401"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error403"
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/Error500"
+ *         )
+ *     )
+ * )
+ */
+class CampaignInteractionCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionDestroyByCampaignAndUserControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionDestroyByCampaignAndUserControllerDoc.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Delete(
+ *     path="/api/campaign-interactions/delete",
+ *     summary="Supprimer une interaction par campagne et utilisateur",
+ *     description="Supprime une interaction spécifique associée à un utilisateur et une campagne.
+ *     Nécessite que la combinaison (campaign_id, user_id) existe.",
+ *     tags={"Campaign Interactions"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             required={"campaign_id", "user_id"},
+ *
+ *             @OA\Property(
+ *                 property="campaign_id",
+ *                 type="integer",
+ *                 description="Identifiant de la campagne",
+ *                 example=12
+ *             ),
+ *             @OA\Property(
+ *                 property="user_id",
+ *                 type="integer",
+ *                 description="Identifiant de l’utilisateur",
+ *                 example=45
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Interaction supprimée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={"message": "Interaction supprimée avec succès"}
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Aucune interaction trouvée pour ce couple campaign_id / user_id",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={"message": "Aucune interaction trouvée pour ce couple campaign_id / user_id"}
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide (paramètres manquants ou invalides)",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={"error": "Le champ campaign_id est requis et doit être un entier valide"}
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={"error": "Unauthenticated"}
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={"error": "Vous n’avez pas la permission de supprimer cette interaction"}
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={"error": "Erreur interne du serveur, veuillez réessayer plus tard"}
+ *         )
+ *     )
+ * )
+ */
+class CampaignInteractionDestroyByCampaignAndUserControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionDestroyControllerDoc.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Delete(
+ *     path="/api/campaign-interactions/{id}",
+ *     summary="Supprimer une interaction par ID",
+ *     description="Supprime une interaction spécifique grâce à son identifiant unique.",
+ *     tags={"Campaign Interactions"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="Identifiant de l’interaction",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=101)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Interaction supprimée avec succès",
+ *
+ *         @OA\JsonContent(example={"message": "Interaction supprimée avec succès"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Interaction non trouvée",
+ *
+ *         @OA\JsonContent(example={"error": "Aucune interaction trouvée avec cet identifiant"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(example={"error": "Unauthenticated"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(example={"error": "Vous n’avez pas la permission de supprimer cette interaction"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(example={"error": "Erreur interne du serveur, veuillez réessayer plus tard"})
+ *     )
+ * )
+ */
+class CampaignInteractionDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionIndexControllerDoc.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-interactions",
+ *     summary="Lister toutes les interactions",
+ *     description="Retourne la liste complète des interactions disponibles.",
+ *     tags={"Campaign Interactions"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des interactions récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignInteractionResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=120)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignInteractionIndexControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionLikeControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionLikeControllerDoc.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaign-interactions/{interactionId}/like",
+ *     summary="Ajouter un like à une interaction",
+ *     description="Incrémente le compteur de likes pour une interaction spécifique.",
+ *     tags={"Campaign Interactions"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="interactionId",
+ *         in="path",
+ *         description="Identifiant de l'interaction",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=101)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Like ajouté avec succès",
+ *
+ *         @OA\JsonContent(type="object", example={"message": "Like ajouté avec succès"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Impossible d'ajouter un like",
+ *                 "errors": {
+ *                     "interactionId": {"L'identifiant fourni est invalide."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignInteractionLikeControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionShowControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionShowControllerDoc.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-interactions/{id}",
+ *     summary="Afficher une interaction spécifique",
+ *     description="Retourne les détails d'une interaction utilisateur avec une campagne.",
+ *     tags={"Campaign Interactions"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="Identifiant de l'interaction",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=101)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Interaction récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 ref="#/components/schemas/CampaignInteractionResource"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignInteractionShowControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionStatsControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionStatsControllerDoc.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-interactions/{campaignId}/stats",
+ *     summary="Récupérer les statistiques d'interactions d'une campagne",
+ *     description="Retourne le nombre total de likes, vues et partages pour une campagne spécifique.",
+ *     tags={"Campaign Interactions"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="campaignId",
+ *         in="path",
+ *         description="Identifiant de la campagne",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Statistiques récupérées avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "likes": 120,
+ *                 "views": 1500,
+ *                 "shares": 45
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignInteractionStatsControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionStoreControllerDoc.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaign-interactions",
+ *     summary="Créer une nouvelle interaction pour une campagne",
+ *     description="Crée une interaction (like, view, share, etc.) pour une campagne spécifique.",
+ *     tags={"Campaign Interactions"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données de l'interaction à créer",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             required={"campaign_id","user_id","type"},
+ *
+ *             @OA\Property(property="campaign_id", type="integer", example=12),
+ *             @OA\Property(property="user_id", type="integer", example=45),
+ *             @OA\Property(property="type", type="string", example="like")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Interaction créée avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/CampaignInteractionResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides",
+ *                 "errors": {
+ *                     "type": {"Le champ type doit être 'like', 'view' ou 'share'."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignInteractionStoreControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignInteraction/CampaignInteractionUpdateControllerDoc.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignInteraction;
+
+/**
+ * @OA\Put(
+ *     path="/api/campaign-interactions/{id}",
+ *     summary="Mettre à jour une interaction existante",
+ *     description="Met à jour les informations d'une interaction spécifique (like, view, share, etc.) d'une campagne.",
+ *     tags={"Campaign Interactions"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'interaction à mettre à jour",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=101)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données de l'interaction à mettre à jour",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="type", type="string", example="share"),
+ *             @OA\Property(property="likes", type="integer", example=2),
+ *             @OA\Property(property="views", type="integer", example=15),
+ *             @OA\Property(property="shares", type="integer", example=3)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Interaction mise à jour avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/CampaignInteractionResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides",
+ *                 "errors": {
+ *                     "likes": {"Le nombre de likes doit être un entier positif."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignInteractionUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignTemplate/CampaignTemplateControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignTemplate/CampaignTemplateControllerDoc.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignTemplate;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-templates",
+ *     summary="Lister tous les modèles de campagnes avec stats",
+ *     description="Retourne la liste de tous les modèles de campagnes avec le rating et le nombre d'utilisations.",
+ *     tags={"Campaign Templates"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des templates récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/CampaignTemplateResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignTemplateControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignTemplate/CampaignTemplateShowControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignTemplate/CampaignTemplateShowControllerDoc.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignTemplate;
+
+/**
+ * @OA\Get(
+ *     path="/api/campaign-templates/{id}",
+ *     summary="Récupérer un modèle de campagne spécifique avec stats",
+ *     description="Retourne un modèle de campagne avec ses statistiques (rating, nombre d'utilisations).",
+ *     tags={"Campaign Templates"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du template de campagne",
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Template récupéré avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/CampaignTemplateResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Template introuvable",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error400")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CampaignTemplateShowControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignTemplate/CategoryControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignTemplate/CategoryControllerDoc.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignTemplate;
+
+/**
+ * @OA\Get(
+ *     path="/api/categories",
+ *     summary="Récupérer la liste des catégories",
+ *     description="Retourne toutes les catégories disponibles avec leurs icônes.",
+ *     tags={"Campaign Templates"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des catégories récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="array",
+ *
+ *             @OA\Items(
+ *                 type="object",
+ *
+ *                 @OA\Property(
+ *                     property="name",
+ *                     type="string",
+ *                     example="Marketing",
+ *                     description="Nom de la catégorie"
+ *                 ),
+ *                 @OA\Property(
+ *                     property="icon",
+ *                     type="string",
+ *                     example="marketing-icon",
+ *                     description="Nom ou chemin de l'icône"
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error403")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error500")
+ *     )
+ * )
+ */
+class CategoryControllerDoc {}

--- a/app/OpenApi/Controllers/CampaignTemplate/TemplateRatingControllerDoc.php
+++ b/app/OpenApi/Controllers/CampaignTemplate/TemplateRatingControllerDoc.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\OpenApi\Controllers\CampaignTemplate;
+
+/**
+ * @OA\Post(
+ *     path="/api/campaign-templates/{templateId}/rating",
+ *     summary="Ajouter ou mettre à jour le rating d'un template",
+ *     description="Permet à un utilisateur de créer ou modifier son rating pour un template donné.",
+ *     tags={"Campaign Templates"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="templateId",
+ *         in="path",
+ *         required=true,
+ *         description="ID du template",
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="rating", type="number", example=4.5)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Rating enregistré avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": true,
+ *                 "message": "Rating enregistré avec succès",
+ *                 "data": {"template_id": 7, "user_id": 12, "rating": 4.5}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Rating invalide ou manquant"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *      ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation des champs",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides.",
+ *                 "errors": {
+ *                     "rating": {"Le champ rating doit être un nombre entre 0 et 5."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/Error401")
+ *     )
+ * )
+ */
+class TemplateRatingControllerDoc {}

--- a/app/OpenApi/Controllers/Dashboard/DashboardControllerDoc.php
+++ b/app/OpenApi/Controllers/Dashboard/DashboardControllerDoc.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\OpenApi\Controllers\Dashboard;
+
+/**
+ * @OA\Get(
+ *     path="/api/dashboard/indicators/{userId}",
+ *     summary="Récupérer les indicateurs du dashboard pour un utilisateur",
+ *     description="Retourne les statistiques des campagnes et interactions d'un utilisateur, y compris les indicateurs globaux et ceux venant d'autres utilisateurs.",
+ *     tags={"Dashboard"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="userId",
+ *         in="path",
+ *         required=true,
+ *         description="Identifiant de l'utilisateur",
+ *
+ *         @OA\Schema(type="integer", example=45)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Indicateurs récupérés avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="totalCampaigns", type="integer", example=10),
+ *                 @OA\Property(property="totalViews", type="integer", example=1200),
+ *                 @OA\Property(property="totalLikes", type="integer", example=300),
+ *                 @OA\Property(property="totalShares", type="integer", example=75),
+ *                 @OA\Property(property="engagementRate", type="number", format="float", example=31.3),
+ *                 @OA\Property(
+ *                     property="externalInteractions",
+ *                     type="object",
+ *                     @OA\Property(property="views", type="integer", example=800),
+ *                     @OA\Property(property="likes", type="integer", example=150),
+ *                     @OA\Property(property="shares", type="integer", example=20)
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous devez être connecté pour accéder à cette ressource"),
+ *             @OA\Property(property="errors", type="object", example={})
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n'avez pas la permission d'accéder à cette ressource"),
+ *             @OA\Property(property="errors", type="object", example={})
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Utilisateur introuvable",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Utilisateur non trouvé"),
+ *             @OA\Property(property="errors", type="object", example={})
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Une erreur de serveur est survenue")
+ *         )
+ *     )
+ * )
+ */
+class DashboardControllerDoc {}

--- a/app/OpenApi/Controllers/EmailVerification/EmailVerificationStatusControllerDoc.php
+++ b/app/OpenApi/Controllers/EmailVerification/EmailVerificationStatusControllerDoc.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\OpenApi\Controllers\EmailVerification;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/email/verification-status",
+ *     summary="Statut de vérification de l'email",
+ *     description="Retourne le statut de vérification de l'email de l'utilisateur connecté",
+ *     tags={"Email Verification"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Statut récupéré avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="verified", type="boolean", example=false),
+ *             @OA\Property(property="email", type="string", example="john.doe@example.com"),
+ *             @OA\Property(property="verified_at", type="string", format="date-time", nullable=true)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Vous devez être connecté"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Vous n'avez pas la permission de consulter ce statut"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Utilisateur introuvable",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Utilisateur non trouvé"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Une erreur interne est survenue"})
+ *     )
+ * )
+ */
+class EmailVerificationStatusControllerDoc {}

--- a/app/OpenApi/Controllers/EmailVerification/SendEmailVerificationControllerDoc.php
+++ b/app/OpenApi/Controllers/EmailVerification/SendEmailVerificationControllerDoc.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\OpenApi\Controllers\EmailVerification;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/email/send-verification",
+ *     summary="Envoyer email de vérification",
+ *     description="Envoie un email de vérification si l'email n'est pas encore vérifié",
+ *     tags={"Email Verification"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Email de vérification envoyé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Email de vérification envoyé.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Requête invalide ou email déjà vérifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "L'email est déjà vérifié"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Vous devez être connecté"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès interdit",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Vous n'avez pas la permission d'envoyer cet email"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Utilisateur introuvable",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Utilisateur non trouvé"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=429,
+ *         description="Trop de requêtes (rate limit)",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Trop de tentatives, veuillez réessayer plus tard"})
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse",
+ *             example={"success": false, "message": "Une erreur interne est survenue"})
+ *     )
+ * )
+ */
+class SendEmailVerificationControllerDoc {}

--- a/app/OpenApi/Controllers/EmailVerification/VerifyEmailControllerDoc.php
+++ b/app/OpenApi/Controllers/EmailVerification/VerifyEmailControllerDoc.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\OpenApi\Controllers\EmailVerification;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/email/verify",
+ *     summary="Vérifier l'email",
+ *     description="Vérifie l'email à partir des paramètres du lien de vérification",
+ *     tags={"Email Verification"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"id", "hash", "expires", "signature"},
+ *
+ *             @OA\Property(property="id", type="integer", example=1),
+ *             @OA\Property(property="hash", type="string", example="abc123hash"),
+ *             @OA\Property(property="expires", type="integer", example=1700000000),
+ *             @OA\Property(property="signature", type="string", example="signatureexample")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Email vérifié avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Email vérifié avec succès."),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="object",
+ *                 @OA\Property(property="user", ref="#/components/schemas/User"),
+ *                 @OA\Property(property="token", type="string", example="1|a1b2c3..."),
+ *                 @OA\Property(property="token_type", type="string", example="Bearer")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Lien invalide, expiré ou email déjà vérifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Le lien de vérification est invalide ou a expiré."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Utilisateur introuvable",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Aucun utilisateur trouvé pour l'ID fourni."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=409,
+ *         description="Email déjà vérifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Cet email est déjà vérifié."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur interne est survenue, veuillez réessayer plus tard."
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class VerifyEmailControllerDoc {}

--- a/app/OpenApi/Controllers/Features/FeaturesCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/Features/FeaturesCriteriaControllerDoc.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\OpenApi\Controllers\Features;
+
+/**
+ * @OA\Get(
+ *     path="/api/features/search",
+ *     summary="Rechercher des fonctionnalités selon des critères",
+ *     description="Filtre les Features par critères",
+ *     tags={"Features"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         required=false,
+ *         description="Filtrer par ID utilisateur",
+ *
+ *         @OA\Schema(type="integer", example=2)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="name",
+ *         in="query",
+ *         required=false,
+ *         description="Filtrer par nom de feature",
+ *
+ *         @OA\Schema(type="string", example="Campagne")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Résultats filtrés",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/FeatureCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Non autorisé",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de rechercher ces fonctionnalités",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class FeaturesCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/Features/FeaturesDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/Features/FeaturesDestroyControllerDoc.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\OpenApi\Controllers\Features;
+
+/**
+ * @OA\Delete(
+ *     path="/api/features/{id}",
+ *     summary="Supprimer une fonctionnalité",
+ *     description="Supprime un Feature par son ID.",
+ *     tags={"Features"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(name="id", in="path", required=true, description="ID du Feature", @OA\Schema(type="integer", example=10)),
+ *
+ *     @OA\Response(response=200, description="Supprimé avec succès", @OA\JsonContent(example={"message":"Supprimé avec succès."})),
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Non autorisé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=404, description="Feature non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class FeaturesDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/Features/FeaturesIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/Features/FeaturesIndexControllerDoc.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\OpenApi\Controllers\Features;
+
+/**
+ * @OA\Get(
+ *     path="/api/features",
+ *     summary="Lister toutes les fonctionnalités",
+ *     description="Retourne la liste complète des Features disponibles.",
+ *     tags={"Features"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des fonctionnalités récupérée avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/FeatureCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Non autorisé",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de lister les fonctionnalités",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class FeaturesIndexControllerDoc {}

--- a/app/OpenApi/Controllers/Features/FeaturesShowControllerDoc.php
+++ b/app/OpenApi/Controllers/Features/FeaturesShowControllerDoc.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\OpenApi\Controllers\Features;
+
+/**
+ * @OA\Get(
+ *     path="/api/features/{id}",
+ *     summary="Voir une fonctionnalité",
+ *     description="Retourne les détails d'un Feature selon son ID.",
+ *     tags={"Features"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du Feature",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Response(response=200, description="Feature trouvé", @OA\JsonContent(ref="#/components/schemas/FeatureResource")),
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse", example={"success":false,"message":"Unauthenticated"})),
+ *     @OA\Response(response=403, description="Non autorisé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse", example={"success":false,"message":"Accès interdit"})),
+ *     @OA\Response(response=404, description="Feature non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse", example={"success":false,"message":"Feature introuvable"})),
+ *     @OA\Response(response=500, description="Erreur serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse", example={"success":false,"message":"Erreur serveur"}))
+ * )
+ */
+class FeaturesShowControllerDoc {}

--- a/app/OpenApi/Controllers/Features/FeaturesStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/Features/FeaturesStoreControllerDoc.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\OpenApi\Controllers\Features;
+
+/**
+ * @OA\Post(
+ *     path="/api/features",
+ *     summary="Créer une nouvelle fonctionnalité",
+ *     description="Crée un Feature et le retourne.",
+ *     tags={"Features"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             required={"name"},
+ *
+ *             @OA\Property(property="name", type="string", example="Nouvelle fonctionnalité")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Feature créée avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/FeatureResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Non autorisé",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de créer une fonctionnalité",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides",
+ *                 "errors": {
+ *                     "name": {"Le champ name est obligatoire ou trop long"},
+ *                     "other_field": {"Valeur invalide pour other_field"}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class FeaturesStoreControllerDoc {}

--- a/app/OpenApi/Controllers/Features/FeaturesUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/Features/FeaturesUpdateControllerDoc.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\OpenApi\Controllers\Features;
+
+/**
+ * @OA\Put(
+ *     path="/api/features/{id}",
+ *     summary="Mettre à jour une fonctionnalité",
+ *     description="Met à jour un Feature existant.",
+ *     tags={"Features"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du Feature",
+ *
+ *         @OA\Schema(type="integer", example=8)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="name", type="string", example="Nom modifié")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Feature mis à jour",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/FeatureResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Non autorisé",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de modifier cette fonctionnalité",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Feature non trouvé",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Aucune fonctionnalité trouvée avec l'ID fourni",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Les données fournies sont invalides",
+ *                 "errors": {
+ *                     "name": {"Le champ name est obligatoire ou invalide"}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class FeaturesUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageCriteriaControllerDoc.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Get(
+ *     path="/api/images/search",
+ *     summary="Lister les images selon des critères",
+ *     description="Retourne une collection d’images filtrées par critères (par défaut limité à l’utilisateur connecté sauf si admin).",
+ *     tags={"Images"},
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID de campagne",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="is_published",
+ *         in="query",
+ *         description="Filtrer les images publiées ou non",
+ *         required=false,
+ *
+ *         @OA\Schema(type="boolean", example=true)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des images filtrées",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ImageCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé (droits insuffisants)",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de voir ces images",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Aucune image trouvée pour les critères fournis",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Aucune image correspondante trouvée",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             ref="#/components/schemas/ErrorResponse",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class ImageCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageDestroyControllerDoc.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Delete(
+ *     path="/api/images/{id}",
+ *     summary="Supprimer une image",
+ *     description="Supprime une image spécifique par son ID.",
+ *     tags={"Images"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'image à supprimer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Image supprimée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour supprimer une image",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de supprimer cette image",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Image non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Aucune image trouvée avec l'ID fourni",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Erreur interne du serveur lors de la suppression de l'image",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class ImageDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageGenerationControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageGenerationControllerDoc.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Post(
+ *     path="/api/images/generate",
+ *     summary="Générer une image",
+ *     description="Génère une image à partir d'un prompt et l'associe à une campagne.",
+ *     tags={"Images"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="prompt", type="string", example="Une illustration futuriste d'une ville"),
+ *             @OA\Property(property="campaign_id", type="integer", example=3),
+ *             @OA\Property(property="prompt_id", type="integer", example=12)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Image générée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Image générée avec succès"),
+ *             @OA\Property(property="images", type="array", @OA\Items(ref="#/components/schemas/ImageResource")),
+ *             @OA\Property(property="data", type="object",
+ *                 @OA\Property(property="image", ref="#/components/schemas/ImageResource"),
+ *                 @OA\Property(property="image_url", type="string", example="/images/example.jpg")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour générer une image",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de générer une image pour cette campagne",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Validation échouée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Données invalides",
+ *                 "errors": {
+ *                     "prompt": {"Le champ prompt est obligatoire."},
+ *                     "campaign_id": {"Le champ campaign_id doit être un entier valide."}
+ *                 }
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Erreur interne du serveur lors de la génération de l'image",
+ *                 "errors": {}
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class ImageGenerationControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageIndexControllerDoc.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Get(
+ *     path="/api/images",
+ *     summary="Lister les images",
+ *     description="Retourne la liste des images de l'utilisateur (ou toutes pour un admin).",
+ *     tags={"Images"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des images",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ImageCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous devez être authentifié.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n'avez pas la permission de visualiser ces images.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur lors de la récupération des images.")
+ *         )
+ *     )
+ * )
+ */
+class ImageIndexControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageShowControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageShowControllerDoc.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Get(
+ *     path="/api/images/{id}",
+ *     summary="Afficher une image",
+ *     description="Retourne les détails d'une image spécifique par son ID.",
+ *     tags={"Images"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'image à récupérer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails de l'image",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ImageResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous devez être authentifié.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n'avez pas la permission de visualiser cette image.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Image non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Image introuvable avec l'ID fourni.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur lors de la récupération de l'image.")
+ *         )
+ *     )
+ * )
+ */
+class ImageShowControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageStoreControllerDoc.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Post(
+ *     path="/api/images",
+ *     summary="Créer une nouvelle image",
+ *     description="Crée une image pour une campagne.",
+ *     tags={"Images"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="path", type="string", example="/images/example.jpg"),
+ *             @OA\Property(property="campaign_id", type="integer", example=3),
+ *             @OA\Property(property="prompt_id", type="integer", example=12)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Image créée avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ImageResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous devez être connecté pour accéder à cette ressource.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n’avez pas la permission de créer une image pour cette campagne.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Validation échouée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Les données fournies sont invalides."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 @OA\Property(property="path", type="array", @OA\Items(type="string", example="Le champ path est obligatoire.")),
+ *                 @OA\Property(property="campaign_id", type="array", @OA\Items(type="string", example="La campagne spécifiée est introuvable."))
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur lors de la création de l'image.")
+ *         )
+ *     )
+ * )
+ */
+class ImageStoreControllerDoc {}

--- a/app/OpenApi/Controllers/Image/ImageUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/Image/ImageUpdateControllerDoc.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\OpenApi\Controllers\Image;
+
+/**
+ * @OA\Put(
+ *     path="/api/images/{id}",
+ *     summary="Mettre à jour une image",
+ *     description="Met à jour les informations d'une image spécifique.",
+ *     tags={"Images"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'image à mettre à jour",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="path", type="string", example="/images/updated.jpg")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Image mise à jour avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ImageResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous devez être connecté pour effectuer cette action.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n’avez pas la permission de modifier cette image.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Image non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="L'image avec l'ID fourni est introuvable.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Validation échouée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Les données fournies sont invalides."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 @OA\Property(property="path", type="array", @OA\Items(type="string", example="Le champ path doit être une URL valide."))
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur lors de la mise à jour de l'image.")
+ *         )
+ *     )
+ * )
+ */
+class ImageUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageCriteriaControllerDoc.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/landing-pages/search",
+ *     summary="Lister les landing pages selon des critères",
+ *     description="Retourne la liste des landing pages filtrées selon les critères fournis. Les utilisateurs non-admin ne voient que leurs propres landing pages.",
+ *     tags={"LandingPages"},
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par ID utilisateur (uniquement admin)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=3)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID campagne",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des landing pages",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/LandingPageCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur inattendue",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur lors de la récupération des landing pages.")
+ *         )
+ *     )
+ * )
+ */
+class LandingPageCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageDestroyControllerDoc.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+/**
+ * @OA\Delete(
+ *     path="/api/landing-pages/{id}",
+ *     summary="Supprimer une landing page",
+ *     description="Supprime une landing page spécifique.",
+ *     tags={"LandingPages"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de la landing page",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Landing page supprimée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Landing page supprimée avec succès")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Landing page non trouvée",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur lors de la suppression de la landing page")
+ *         )
+ *     )
+ * )
+ */
+class LandingPageDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageGenerateControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageGenerateControllerDoc.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+/**
+ * @OA\Post(
+ *     path="/api/landing-pages/generate",
+ *     summary="Générer une landing page",
+ *     description="Génère une landing page à partir d'un prompt pour une campagne spécifique.",
+ *     tags={"LandingPages"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données pour générer la landing page",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="prompt", type="string", example="Créer une landing page pour notre nouveau produit X."),
+ *             @OA\Property(property="campaign_id", type="integer", example=12),
+ *             @OA\Property(property="prompt_id", type="integer", example=7)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Landing page générée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", type="object",
+ *                 @OA\Property(property="id", type="integer", example=1),
+ *                 @OA\Property(property="content", type="array",
+ *
+ *                     @OA\Items(type="string", example={"Titre principal", "Sous-titre", "CTA"})
+ *                 ),
+ *
+ *                 @OA\Property(property="campaign_id", type="integer", example=12),
+ *                 @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 16:00:00"),
+ *             ),
+ *             @OA\Property(property="message", type="string", example="Landing page générée avec succès")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Fallback utilisé suite à une erreur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", type="object"),
+ *             @OA\Property(property="fallback", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Landing page générée avec un template de base suite à une erreur")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Validation échouée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Validation failed"),
+ *             @OA\Property(property="errors", type="object",
+ *                 example={"prompt": {"Le champ prompt est requis"}, "campaign_id": {"Le champ campaign_id doit être un entier"}}
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur lors de la génération de la landing page"),
+ *             @OA\Property(property="error", type="string", example="Détails de l'exception")
+ *         )
+ *     )
+ * )
+ */
+class LandingPageGenerateControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageIndexControllerDoc.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+/**
+ * @OA\Get(
+ *     path="/api/landing-pages",
+ *     summary="Liste des landing pages",
+ *     description="Retourne la liste des landing pages, filtrable par `campaign_id`.",
+ *     tags={"LandingPages"},
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID de campagne",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des landing pages",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/LandingPageResource")
+ *             ),
+ *
+ *             @OA\Property(property="meta", type="object",
+ *                 @OA\Property(property="total", type="integer", example=5)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Ressource non trouvée",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     )
+ * )
+ */
+class LandingPageIndexControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageShowControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageShowControllerDoc.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/landing-pages/{id}",
+ *     summary="Afficher une landing page",
+ *     description="Retourne les détails d'une landing page spécifique.",
+ *     tags={"LandingPages"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de la landing page",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails de la landing page",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", ref="#/components/schemas/LandingPageResource")
+ *         )
+ *     )
+ * )
+ */
+class LandingPageShowControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageStoreControllerDoc.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+/**
+ * @OA\Post(
+ *     path="/api/landing-pages",
+ *     summary="Créer une landing page",
+ *     description="Crée une nouvelle landing page pour une campagne spécifique.",
+ *     tags={"LandingPages"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(
+ *                 property="content",
+ *                 type="array",
+ *
+ *                 @OA\Items(
+ *                     type="object",
+ *
+ *                     @OA\Property(property="type", type="string", example="text"),
+ *                     @OA\Property(property="value", type="string", example="Bienvenue")
+ *                 )
+ *             ),
+ *             @OA\Property(property="campaign_id", type="integer", example=5),
+ *             @OA\Property(property="prompt_id", type="integer", example=12)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Landing page créée avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", ref="#/components/schemas/LandingPageResource")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Validation échouée",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Validation failed"),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 @OA\Property(
+ *                     property="content",
+ *                     type="array",
+ *
+ *                     @OA\Items(type="string", example="Le champ content est requis")
+ *                 ),
+ *
+ *                 @OA\Property(
+ *                     property="campaign_id",
+ *                     type="array",
+ *
+ *                     @OA\Items(type="string", example="Le champ campaign_id est requis")
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/ErrorResponse")
+ *     )
+ * )
+ */
+class LandingPageStoreControllerDoc {}

--- a/app/OpenApi/Controllers/LandingPage/LandingPageUpadeControllerDoc.php
+++ b/app/OpenApi/Controllers/LandingPage/LandingPageUpadeControllerDoc.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\OpenApi\Controllers\LandingPage;
+
+/**
+ * @OA\Put(
+ *     path="/api/landing-pages/{id}",
+ *     summary="Mettre à jour une landing page",
+ *     description="Met à jour le contenu d'une landing page spécifique.",
+ *     tags={"LandingPages"},
+ *     security={{"bearerAuth":{}}},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID de la landing page à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             required={"content"},
+ *
+ *             @OA\Property(
+ *                 property="content",
+ *                 type="object",
+ *                 example={"title": "Nouvelle landing page", "sections": {"header": "Bienvenue", "footer": "Contactez-nous"}}
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Landing page mise à jour avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Landing page mise à jour avec succès"),
+ *             @OA\Property(property="data", ref="#/components/schemas/LandingPageResource")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous devez être connecté pour accéder à cette ressource.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n’avez pas la permission de modifier cette landing page.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Landing page non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="La landing page demandée est introuvable.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Les données fournies sont invalides."),
+ *             @OA\Property(property="errors", type="object",
+ *                 example={"content": {"Le champ content est obligatoire."}}
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Une erreur inattendue est survenue lors de la mise à jour de la landing page.")
+ *         )
+ *     )
+ * )
+ */
+class LandingPageUpadeControllerDoc {}

--- a/app/OpenApi/Controllers/Mvola/AdminPaymentControllerDoc.php
+++ b/app/OpenApi/Controllers/Mvola/AdminPaymentControllerDoc.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\OpenApi\Controllers\Mvola;
+
+/**
+ * @OA\Get(
+ *     path="/api/admin/payments",
+ *     summary="Lister tous les paiements",
+ *     description="Retourne la liste de tous les paiements avec les informations utilisateur et transaction.",
+ *     tags={"Payments"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des paiements",
+ *
+ *         @OA\JsonContent(
+ *             type="array",
+ *
+ *             @OA\Items(
+ *
+ *                 @OA\Property(property="id", type="integer", example=12),
+ *                 @OA\Property(property="username", type="string", example="John Doe"),
+ *                 @OA\Property(property="amount", type="number", format="float", example=5000),
+ *                 @OA\Property(property="currency", type="string", example="Ar"),
+ *                 @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 15:30:00"),
+ *                 @OA\Property(property="expiration_date", type="string", format="date-time", example="2025-10-25 15:30:00"),
+ *                 @OA\Property(property="transaction_reference", type="string", example="TRX123456789")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à cette ressource."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission d'accéder à ces paiements."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Ressource non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Aucun paiement trouvé."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Erreur serveur interne"
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class AdminPaymentControllerDoc {}

--- a/app/OpenApi/Controllers/Mvola/PaymentControllerDoc.php
+++ b/app/OpenApi/Controllers/Mvola/PaymentControllerDoc.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\OpenApi\Controllers\Mvola;
+
+/**
+ * @OA\Post(
+ *     path="/api/payments",
+ *     summary="Effectuer un paiement",
+ *     description="Crée un paiement pour un utilisateur et active le tarif correspondant.",
+ *     tags={"Payments"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="amount", type="string", example="5000"),
+ *             @OA\Property(property="currency", type="string", example="Ar"),
+ *             @OA\Property(property="description", type="string", example="Paiement Pro"),
+ *             @OA\Property(property="customer_msisdn", type="string", example="0341234567"),
+ *             @OA\Property(property="merchant_msisdn", type="string", example="0337654321")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Paiement effectué avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="id", type="integer", example=12),
+ *             @OA\Property(property="amount", type="number", format="float", example=5000),
+ *             @OA\Property(property="currency", type="string", example="Ar"),
+ *             @OA\Property(property="transaction_reference", type="string", example="TRX123456789"),
+ *             @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 15:30:00")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour effectuer un paiement."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission d'effectuer ce paiement."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Ressource non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Utilisateur ou tarif introuvable."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur lors du paiement",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Payment error: Montant invalide"
+ *             }
+ *         )
+ *     )
+ * )
+ *
+ * @OA\Get(
+ *     path="/api/payments/user",
+ *     summary="Lister les paiements de l'utilisateur connecté",
+ *     description="Retourne la liste des paiements effectués par l'utilisateur connecté.",
+ *     tags={"Payments"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des paiements de l'utilisateur",
+ *
+ *         @OA\JsonContent(
+ *             type="array",
+ *
+ *             @OA\Items(
+ *
+ *                 @OA\Property(property="amount", type="number", format="float", example=5000),
+ *                 @OA\Property(property="currency", type="string", example="Ar"),
+ *                 @OA\Property(property="transaction_reference", type="string", example="TRX123456789"),
+ *                 @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 15:30:00")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous devez être connecté pour accéder à vos paiements."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Vous n'avez pas la permission de consulter ces paiements."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Ressource non trouvée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Aucun paiement trouvé pour cet utilisateur."
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             example={
+ *                 "success": false,
+ *                 "message": "Erreur serveur interne"
+ *             }
+ *         )
+ *     )
+ * )
+ */
+class PaymentControllerDoc {}

--- a/app/OpenApi/Controllers/PasswordReset/ResetPasswordControllerDoc.php
+++ b/app/OpenApi/Controllers/PasswordReset/ResetPasswordControllerDoc.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\OpenApi\Controllers\PasswordReset;
+
+/**
+ * @OA\Post(
+ *     path="/api/password/reset",
+ *     summary="Réinitialiser le mot de passe",
+ *     description="Réinitialise le mot de passe utilisateur avec un token de réinitialisation valide",
+ *     operationId="resetPassword",
+ *     tags={"PasswordReset"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Données pour réinitialiser le mot de passe",
+ *
+ *         @OA\JsonContent(
+ *             required={"token", "email", "password", "password_confirmation"},
+ *
+ *             @OA\Property(property="token", type="string", example="token123"),
+ *             @OA\Property(property="email", type="string", format="email", example="user@example.com"),
+ *             @OA\Property(property="password", type="string", format="password", example="NewPassword123!"),
+ *             @OA\Property(property="password_confirmation", type="string", format="password", example="NewPassword123!")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Mot de passe réinitialisé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Mot de passe réinitialisé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Données de validation invalides",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Les données fournies sont invalides."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 example={
+ *                     "email": {"L'adresse email est invalide."},
+ *                     "password": {
+ *                         "Le mot de passe doit contenir au moins 8 caractères.",
+ *                         "Le mot de passe doit contenir au moins une lettre majuscule.",
+ *                         "Le mot de passe doit contenir au moins un chiffre."
+ *                     },
+ *                     "password_confirmation": {"La confirmation du mot de passe ne correspond pas."}
+ *                 }
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur interne",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Une erreur interne est survenue. Veuillez réessayer plus tard."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 example={
+ *                     "server": {"Erreur lors de la mise à jour du mot de passe."}
+ *                 }
+ *             ),
+ *             @OA\Property(property="debug", type="object", example={}, description="Informations de débogage (uniquement en environnement de développement)")
+ *         )
+ *     )
+ * )
+ */
+class ResetPasswordControllerDoc {}

--- a/app/OpenApi/Controllers/PasswordReset/SendPasswordResetLinkControllerDoc.php
+++ b/app/OpenApi/Controllers/PasswordReset/SendPasswordResetLinkControllerDoc.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\OpenApi\Controllers\PasswordReset;
+
+/**
+ * @OA\Post(
+ *     path="/api/password/email",
+ *     summary="Envoyer un lien de réinitialisation du mot de passe",
+ *     description="Envoie un email contenant un lien de réinitialisation de mot de passe à l'adresse spécifiée",
+ *     operationId="sendPasswordResetLink",
+ *     tags={"PasswordReset"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *         description="Adresse email pour envoyer le lien",
+ *
+ *         @OA\JsonContent(
+ *             required={"email"},
+ *
+ *             @OA\Property(
+ *                 property="email",
+ *                 type="string",
+ *                 format="email",
+ *                 description="Adresse email de l'utilisateur",
+ *                 example="user@example.com"
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Lien de réinitialisation envoyé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Lien de réinitialisation envoyé par email.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Données de validation invalides",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Les données fournies sont invalides."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 example={
+ *                     "email": {
+ *                         "Le champ email est obligatoire.",
+ *                         "L'adresse email doit être une adresse email valide.",
+ *                         "L'adresse email n'existe pas dans notre système.",
+ *                         "Nous ne pouvons pas envoyer d'email à cette adresse.",
+ *                         "Trop de tentatives. Veuillez réessayer dans 5 minutes."
+ *                     }
+ *                 }
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur interne",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue lors de l'envoi de l'email. Veuillez réessayer."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 example={
+ *                     "server": {
+ *                         "Impossible d'envoyer l'email de réinitialisation.",
+ *                         "Erreur de connexion au service d'email.",
+ *                         "Service d'email temporairement indisponible."
+ *                     }
+ *                 }
+ *             )
+ *         )
+ *     )
+ * )
+ */
+class SendPasswordResetLinkControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptCriteriaControllerDoc.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Get(
+ *     path="/api/prompts/search",
+ *     summary="Lister les prompts selon des critères",
+ *     description="Retourne la liste des prompts filtrés selon les critères passés en query. Si l'utilisateur n'est pas admin, il ne verra que ses propres prompts.",
+ *     operationId="searchPrompts",
+ *     tags={"Prompts"},
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID de campagne",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par ID d'utilisateur (admin uniquement)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="search",
+ *         in="query",
+ *         description="Recherche textuelle dans le titre et le contenu",
+ *         required=false,
+ *
+ *         @OA\Schema(type="string", example="marketing")
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="page",
+ *         in="query",
+ *         description="Numéro de page",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", minimum=1, example=1)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="per_page",
+ *         in="query",
+ *         description="Nombre d'éléments par page",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", minimum=1, maximum=100, example=20)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des prompts",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="data", type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/PromptResource")
+ *             ),
+ *
+ *             @OA\Property(property="meta", type="object",
+ *                 @OA\Property(property="total", type="integer", example=10),
+ *                 @OA\Property(property="current_page", type="integer", example=1),
+ *                 @OA\Property(property="last_page", type="integer", example=1),
+ *                 @OA\Property(property="per_page", type="integer", example=20),
+ *                 @OA\Property(property="from", type="integer", example=1),
+ *                 @OA\Property(property="to", type="integer", example=10)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=400, description="Paramètres invalides", @OA\JsonContent(ref="#/components/schemas/Error400")),
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/Error401")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/Error403")),
+ *     @OA\Response(response=500, description="Erreur serveur", @OA\JsonContent(ref="#/components/schemas/Error500"))
+ * )
+ */
+class PromptCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptDestroyControllerDoc.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Delete(
+ *     path="/api/prompts/{id}",
+ *     summary="Supprimer un prompt",
+ *     description="Supprime un prompt spécifique par ID. Seul le propriétaire ou un administrateur peut supprimer un prompt.",
+ *     operationId="deletePrompt",
+ *     tags={"Prompts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du prompt à supprimer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Prompt supprimé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Prompt supprimé avec succès."),
+ *             @OA\Property(property="data", type="object", example={})
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié - Token manquant ou invalide",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Token d'authentification invalide")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé - Pas le propriétaire du prompt",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous n'êtes pas autorisé à supprimer ce prompt")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Prompt non trouvé - ID invalide",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Aucun prompt trouvé avec cet ID")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur serveur lors de la suppression")
+ *         )
+ *     )
+ * )
+ */
+class PromptDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptIndexControllerDoc.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Get(
+ *     path="/api/prompts/index",
+ *     summary="Lister tous les prompts",
+ *     description="Retourne la liste de tous les prompts.",
+ *     tags={"Prompts"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des prompts",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/PromptResource")),
+ *             @OA\Property(property="total", type="integer", example=15)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Non authentifié")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *              ref="#/components/schemas/ErrorResponse",
+ *              example={
+ *                  "success": false,
+ *                  "message": "Vous n’avez pas les permissions nécessaires pour accéder à cette ressource",
+ *                  "errors": {}
+ *              }
+ *          )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *              ref="#/components/schemas/ErrorResponse",
+ *              example={
+ *                  "success": false,
+ *                  "message": "Une erreur interne est survenue lors de la récupération des campagnes"
+ *              }
+ *          )
+ *     )
+ * )
+ */
+class PromptIndexControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptQuotaByUserControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptQuotaByUserControllerDoc.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Get(
+ *     path="/api/prompts/quota/{userId}",
+ *     summary="Obtenir le quota de prompts utilisé par un utilisateur",
+ *     description="Retourne le nombre de prompts utilisés aujourd'hui par un utilisateur donné.",
+ *     tags={"Prompts"},
+ *
+ *     @OA\Parameter(
+ *         name="userId",
+ *         in="path",
+ *         description="ID de l'utilisateur",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Quota de prompts utilisé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", type="object",
+ *                 @OA\Property(property="user_id", type="integer", example=12),
+ *                 @OA\Property(property="daily_quota_used", type="integer", example=5)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class PromptQuotaByUserControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptShowControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptShowControllerDoc.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Get(
+ *     path="/api/prompts/{id}",
+ *     summary="Afficher un prompt",
+ *     description="Retourne les détails d'un prompt spécifique.",
+ *     tags={"Prompts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du prompt",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails du prompt",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/PromptResource")
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=404, description="Prompt non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class PromptShowControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptStoreControllerDoc.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Post(
+ *     path="/api/prompts",
+ *     summary="Créer un prompt",
+ *     description="Crée un nouveau prompt pour une campagne spécifique.",
+ *     tags={"Prompts"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="content", type="string", example="Créer un prompt pour campagne X"),
+ *             @OA\Property(property="campaign_id", type="integer", example=5),
+ *             @OA\Property(property="prompt_id", type="integer", example=12)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Prompt créé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/PromptResource")
+ *     ),
+ *
+ *     @OA\Response(response=400, description="Quota dépassé ou tarif manquant", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=422, description="Validation échouée", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class PromptStoreControllerDoc {}

--- a/app/OpenApi/Controllers/Prompt/PromptUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/Prompt/PromptUpdateControllerDoc.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\OpenApi\Controllers\Prompt;
+
+/**
+ * @OA\Put(
+ *     path="/api/prompts/{id}",
+ *     summary="Mettre à jour un prompt",
+ *     description="Met à jour le contenu d'un prompt spécifique.",
+ *     tags={"Prompts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du prompt",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="content", type="string", example="Nouveau contenu du prompt")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Prompt mis à jour avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/PromptResource")
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=404, description="Prompt non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=422, description="Validation échouée", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class PromptUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/Social/SocialCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/Social/SocialCriteriaControllerDoc.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\OpenApi\Controllers\Social;
+
+/**
+ * @OA\Get(
+ *     path="/api/socials/search",
+ *     summary="Lister les posts sociaux selon des critères",
+ *     description="Retourne la liste des posts sociaux selon les critères fournis pour l'utilisateur connecté. Les admins voient tous les posts.",
+ *     tags={"Socials"},
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par ID utilisateur (automatiquement ajouté si non admin)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=12)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des posts sociaux",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="data", type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/SocialResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class SocialCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/Social/SocialDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/Social/SocialDestroyControllerDoc.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\OpenApi\Controllers\Social;
+
+/**
+ * @OA\Delete(
+ *     path="/api/socials/{id}",
+ *     summary="Supprimer un post social",
+ *     description="Supprime un post social existant.",
+ *     tags={"Socials"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du post social",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post social supprimé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=404, description="Post social non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class SocialDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/Social/SocialIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/Social/SocialIndexControllerDoc.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\OpenApi\Controllers\Social;
+
+/**
+ * @OA\Get(
+ *     path="/api/socials",
+ *     summary="Lister tous les posts sociaux",
+ *     description="Retourne tous les posts sociaux.",
+ *     tags={"Socials"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des posts sociaux",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="data", type="array", @OA\Items(ref="#/components/schemas/SocialResource"))
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class SocialIndexControllerDoc {}

--- a/app/OpenApi/Controllers/Social/SocialShowControllerDoc.php
+++ b/app/OpenApi/Controllers/Social/SocialShowControllerDoc.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\OpenApi\Controllers\Social;
+
+/**
+ * @OA\Get(
+ *     path="/api/socials/{id}",
+ *     summary="Afficher un post social",
+ *     description="Retourne les détails d'un post social spécifique.",
+ *     tags={"Socials"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du post social",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails du post social",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/SocialResource")
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=404, description="Post social non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class SocialShowControllerDoc {}

--- a/app/OpenApi/Controllers/Social/SocialStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/Social/SocialStoreControllerDoc.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\OpenApi\Controllers\Social;
+
+/**
+ * @OA\Post(
+ *     path="/api/socials",
+ *     summary="Créer un post social",
+ *     description="Crée un nouveau post social.",
+ *     tags={"Socials"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="name", type="string", example="Nom du post social")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Post social créé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/SocialResource")
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=422, description="Validation échouée", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class SocialStoreControllerDoc {}

--- a/app/OpenApi/Controllers/Social/SocialUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/Social/SocialUpdateControllerDoc.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\OpenApi\Controllers\Social;
+
+/**
+ * @OA\Put(
+ *     path="/api/socials/{id}",
+ *     summary="Mettre à jour un post social",
+ *     description="Met à jour un post social existant.",
+ *     tags={"Socials"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du post social",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=7)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="name", type="string", example="Nom du post social mis à jour")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post social mis à jour",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/SocialResource")
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=403, description="Accès refusé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=404, description="Post social non trouvé", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=422, description="Validation échouée", @OA\JsonContent(ref="#/components/schemas/ErrorResponse")),
+ *     @OA\Response(response=500, description="Erreur interne du serveur", @OA\JsonContent(ref="#/components/schemas/ErrorResponse"))
+ * )
+ */
+class SocialUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostCriteriaControllerDoc.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Get(
+ *     path="/api/social-posts",
+ *     summary="Lister les posts sociaux selon des critères",
+ *     description="Retourne les posts sociaux filtrés selon les critères fournis. Les utilisateurs non-admins ne verront que leurs propres posts.",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par ID utilisateur (optionnel, seulement pour admins)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="campaign_id",
+ *         in="query",
+ *         description="Filtrer par ID de campagne (optionnel)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=3)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="social_id",
+ *         in="query",
+ *         description="Filtrer par ID social (optionnel)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=2)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des posts sociaux filtrés",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/SocialPostResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=12)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Non authentifié")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Vous n'avez pas la permission d'accéder à cette ressource")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Ressource non trouvée",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Aucun post social trouvé")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Erreur interne du serveur")
+ *         )
+ *     )
+ * )
+ */
+class SocialPostCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostDestroyControllerDoc.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Delete(
+ *     path="/api/social-posts/{id}",
+ *     summary="Supprimer un post social",
+ *     description="Supprime un post social par ID",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du post social à supprimer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post supprimé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Accès refusé"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Post non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Post social non trouvé"))
+ *     )
+ * )
+ */
+class SocialPostDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostIndexControllerDoc.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Get(
+ *     path="/api/social-posts/index",
+ *     summary="Lister tous les posts sociaux",
+ *     description="Retourne tous les posts sociaux. Les autorisations sont respectées selon le rôle de l'utilisateur.",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des posts sociaux",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/SocialPostResource")
+ *             ),
+ *
+ *             @OA\Property(
+ *                 property="meta",
+ *                 type="object",
+ *                 @OA\Property(property="total", type="integer", example=12)
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Non authentifié"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Accès refusé"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Erreur interne du serveur"))
+ *     )
+ * )
+ */
+class SocialPostIndexControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostRegenerateControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostRegenerateControllerDoc.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Post(
+ *     path="/api/social-posts/{id}/regenerate",
+ *     summary="Régénérer un post social",
+ *     description="Régénère le contenu d'un post social existant",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du post à régénérer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="content", type="string", example="Nouveau contenu régénéré")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post régénéré avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Post régénéré avec succès"),
+ *             @OA\Property(property="data", type="object")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Aucun contenu généré",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="type", type="string", example="no_content")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne de régénération",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Erreur lors de la régénération"),
+ *             @OA\Property(property="type", type="string", example="regeneration_error")
+ *         )
+ *     )
+ * )
+ */
+class SocialPostRegenerateControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostShowControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostShowControllerDoc.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Get(
+ *     path="/api/social-posts/{id}",
+ *     summary="Afficher un post social",
+ *     description="Retourne un post social par son ID",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du post social",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post social trouvé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/SocialPostResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Non authentifié"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Accès refusé"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Post non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Post social non trouvé"))
+ *     )
+ * )
+ */
+class SocialPostShowControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostStoreControllerDoc.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Post(
+ *     path="/api/social-posts",
+ *     summary="Créer un post social",
+ *     description="Créer un nouveau post social à partir d'un prompt et d'une campagne",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="content", type="string", example="Contenu du post"),
+ *             @OA\Property(property="prompt_id", type="integer", example=1),
+ *             @OA\Property(property="social_id", type="integer", example=2),
+ *             @OA\Property(property="campaign_id", type="integer", example=3),
+ *             @OA\Property(property="is_published", type="boolean", example=true)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post créé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/SocialPostResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation ou contenu invalide",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="type", type="string", example="no_content")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Accès refusé"))
+ *     )
+ * )
+ */
+class SocialPostStoreControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialPostUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialPostUpdateControllerDoc.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Put(
+ *     path="/api/social-posts/{id}",
+ *     summary="Mettre à jour un post social",
+ *     description="Met à jour un post social existant",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du post social à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="content", type="string", example="Contenu mis à jour"),
+ *             @OA\Property(property="is_published", type="boolean", example=false)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Post mis à jour",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/SocialPostResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Accès refusé"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Post non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Post social non trouvé"))
+ *     )
+ * )
+ */
+class SocialPostUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/SocialPost/SocialsPostsGenerateControllerDoc.php
+++ b/app/OpenApi/Controllers/SocialPost/SocialsPostsGenerateControllerDoc.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\OpenApi\Controllers\SocialPost;
+
+/**
+ * @OA\Post(
+ *     path="/api/social-posts/generate",
+ *     summary="Générer des posts pour plusieurs plateformes",
+ *     description="Génère et crée des posts sur plusieurs plateformes à partir d'un topic, campagne et prompt",
+ *     tags={"SocialPosts"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="topic", type="string", example="Nouvelle campagne"),
+ *             @OA\Property(property="platforms", type="array", @OA\Items(type="string", enum={"linkedin","x","tiktok"})),
+ *             @OA\Property(property="campaign_id", type="integer", example=1),
+ *             @OA\Property(property="prompt_id", type="integer", example=1),
+ *             @OA\Property(property="tone", type="string", example="friendly"),
+ *             @OA\Property(property="language", type="string", example="french"),
+ *             @OA\Property(property="hashtags", type="string", example="#marketing"),
+ *             @OA\Property(property="target_audience", type="string", example="professionnels du marketing"),
+ *             @OA\Property(property="is_published", type="boolean", example=true)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Posts générés avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="generated", type="boolean", example=true),
+ *             @OA\Property(property="posts", type="array", @OA\Items(ref="#/components/schemas/SocialPostResource")),
+ *             @OA\Property(property="count", type="integer", example=3)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Erreur de validation"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur lors de la génération",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Failed to generate posts"),
+ *             @OA\Property(property="error", type="string", example="Exception message")
+ *         )
+ *     )
+ * )
+ */
+class SocialsPostsGenerateControllerDoc {}

--- a/app/OpenApi/Controllers/Suggestion/SuggestionControllerDoc.php
+++ b/app/OpenApi/Controllers/Suggestion/SuggestionControllerDoc.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\OpenApi\Controllers\Suggestion;
+
+/**
+ * @OA\Get(
+ *     path="/api/suggestions/{userId}",
+ *     summary="Récupérer les suggestions pour un utilisateur",
+ *     description="Renvoie la liste des suggestions pour l'utilisateur authentifié",
+ *     tags={"Suggestions"},
+ *
+ *     @OA\Parameter(
+ *         name="userId",
+ *         in="path",
+ *         description="ID de l'utilisateur",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Suggestions récupérées avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(
+ *                 property="suggestions",
+ *                 type="array",
+ *
+ *                 @OA\Items(
+ *                     type="object",
+ *
+ *                     @OA\Property(property="id", type="integer", example=1),
+ *                     @OA\Property(property="title", type="string", example="Titre de la suggestion"),
+ *                     @OA\Property(property="description", type="string", example="Description détaillée"),
+ *                     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 10:00:00")
+ *                 )
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur lors de la récupération des suggestions",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue lors de la récupération des suggestions.")
+ *         )
+ *     )
+ * )
+ */
+class SuggestionControllerDoc {}

--- a/app/OpenApi/Controllers/Tarif/TarifCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/Tarif/TarifCriteriaControllerDoc.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\OpenApi\Controllers\Tarif;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarifs/search",
+ *     summary="Lister les tarifs selon des critères",
+ *     description="Retourne une liste de tarifs filtrés selon les critères passés en query parameters.",
+ *     tags={"Tarifs"},
+ *
+ *     @OA\Parameter(
+ *         name="name",
+ *         in="query",
+ *         description="Filtrer par nom du tarif",
+ *         required=false,
+ *
+ *         @OA\Schema(type="string")
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="amount",
+ *         in="query",
+ *         description="Filtrer par montant",
+ *         required=false,
+ *
+ *         @OA\Schema(type="number", format="float")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des tarifs récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/TarifResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Unauthorized")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Forbidden")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue")
+ *         )
+ *     )
+ * )
+ */
+class TarifCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/Tarif/TarifDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/Tarif/TarifDestroyControllerDoc.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\OpenApi\Controllers\Tarif;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Delete(
+ *     path="/api/tarifs/{id}",
+ *     summary="Supprimer un tarif",
+ *     description="Supprime un tarif existant par son identifiant",
+ *     tags={"Tarifs"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du tarif à supprimer",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Tarif supprimé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Unauthorized")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Forbidden")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Tarif non trouvé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Tarif introuvable.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue")
+ *         )
+ *     )
+ * )
+ */
+class TarifDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/Tarif/TarifIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/Tarif/TarifIndexControllerDoc.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\OpenApi\Controllers\Tarif;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarifs",
+ *     summary="Lister tous les tarifs",
+ *     description="Récupère la liste complète des tarifs disponibles",
+ *     tags={"Tarifs"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des tarifs",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/TarifResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TarifIndexControllerDoc {}

--- a/app/OpenApi/Controllers/Tarif/TarifShowControllerDoc.php
+++ b/app/OpenApi/Controllers/Tarif/TarifShowControllerDoc.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\OpenApi\Controllers\Tarif;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarifs/{id}",
+ *     summary="Afficher un tarif",
+ *     description="Récupère les informations d’un tarif spécifique par ID",
+ *     tags={"Tarifs"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du tarif",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails du tarif",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Tarif non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Tarif introuvable."))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TarifShowControllerDoc {}

--- a/app/OpenApi/Controllers/Tarif/TarifStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/Tarif/TarifStoreControllerDoc.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\OpenApi\Controllers\Tarif;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/tarifs",
+ *     summary="Créer un tarif",
+ *     description="Crée un nouveau tarif avec les données fournies",
+ *     tags={"Tarifs"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"name", "amount", "max_limit"},
+ *
+ *             @OA\Property(property="name", type="string", example="Tarif Premium"),
+ *             @OA\Property(property="amount", type="number", format="float", example=49.99),
+ *             @OA\Property(property="max_limit", type="integer", example=100)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Tarif créé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="The given data was invalid."),
+ *             @OA\Property(
+ *                 property="errors",
+ *                 type="object",
+ *                 example={"name": {"Le champ name est obligatoire."}}
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TarifStoreControllerDoc {}

--- a/app/OpenApi/Controllers/Tarif/TarifUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/Tarif/TarifUpdateControllerDoc.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\OpenApi\Controllers\Tarif;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Put(
+ *     path="/api/tarifs/{id}",
+ *     summary="Mettre à jour un tarif",
+ *     description="Met à jour les informations d’un tarif existant",
+ *     tags={"Tarifs"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du tarif à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"name", "amount", "max_limit"},
+ *
+ *             @OA\Property(property="name", type="string", example="Tarif Standard"),
+ *             @OA\Property(property="amount", type="number", format="float", example=29.99),
+ *             @OA\Property(property="max_limit", type="integer", example=50)
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Tarif mis à jour avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Tarif non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Tarif introuvable."))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="The given data was invalid."),
+ *             @OA\Property(property="errors", type="object", example={"amount": {"Le champ amount doit être un nombre."}})
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur interne du serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TarifUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/TarifFeature/TarifFeatureCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifFeature/TarifFeatureCriteriaControllerDoc.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+class TarifFeatureCriteriaControllerDoc
+{
+    /**
+     * @OA\Get(
+     *     path="/api/tarif-features",
+     *     summary="Lister les fonctionnalités de tarif selon des critères",
+     *     description="Retourne une collection de fonctionnalités de tarif filtrées par critères (par ex: user_id, tarif_id, etc.).",
+     *     tags={"TarifFeature"},
+     *
+     *     @OA\Parameter(
+     *         name="tarif_id",
+     *         in="query",
+     *         required=false,
+     *         description="Filtrer par identifiant du tarif",
+     *
+     *         @OA\Schema(type="integer", example=5)
+     *     ),
+     *
+     *     @OA\Parameter(
+     *         name="name",
+     *         in="query",
+     *         required=false,
+     *         description="Filtrer par nom de fonctionnalité",
+     *
+     *         @OA\Schema(type="string", example="Support Premium")
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="Collection de fonctionnalités de tarif",
+     *
+     *         @OA\JsonContent(ref="#/components/schemas/TarifFeatureCollection")
+     *     ),
+     *
+     *     @OA\Response(
+     *         response=401,
+     *         description="Non authentifié"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         description="Accès refusé"
+     *     )
+     * )
+     */
+}

--- a/app/OpenApi/Controllers/TarifFeature/TarifFeatureDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifFeature/TarifFeatureDestroyControllerDoc.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Delete(
+ *     path="/api/tarif-features/{id}",
+ *     summary="Supprimer une caractéristique de tarif",
+ *     description="Supprime une feature existante par son ID.",
+ *     tags={"Tarif Features"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du TarifFeature à supprimer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Feature supprimée avec succès",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Supprimé avec succès."))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Feature non trouvée",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="TarifFeature not found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     )
+ * )
+ */
+class TarifFeatureDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/TarifFeature/TarifFeatureIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifFeature/TarifFeatureIndexControllerDoc.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarif-features",
+ *     summary="Récupérer tous les TarifFeatures",
+ *     description="Retourne la liste complète des caractéristiques de tarifs.",
+ *     tags={"Tarif Features"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste complète des TarifFeatures",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifFeatureCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     )
+ * )
+ */
+class TarifFeatureIndexControllerDoc {}

--- a/app/OpenApi/Controllers/TarifFeature/TarifFeatureShowControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifFeature/TarifFeatureShowControllerDoc.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarif-features/{id}",
+ *     summary="Récupérer un TarifFeature par ID",
+ *     description="Retourne les détails d'une caractéristique de tarif spécifique.",
+ *     tags={"Tarif Features"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du TarifFeature",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Détails du TarifFeature",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifFeatureResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TarifFeature non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="TarifFeature not found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     )
+ * )
+ */
+class TarifFeatureShowControllerDoc {}

--- a/app/OpenApi/Controllers/TarifFeature/TarifFeatureStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifFeature/TarifFeatureStoreControllerDoc.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/tarif-features",
+ *     summary="Créer une nouvelle caractéristique de tarif",
+ *     description="Crée un TarifFeature pour un tarif donné.",
+ *     tags={"Tarif Features"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"tarif_id","name"},
+ *
+ *             @OA\Property(property="tarif_id", type="integer", example=2),
+ *             @OA\Property(property="name", type="string", example="Support 24/7")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="TarifFeature créé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifFeatureResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Données invalides",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Validation failed"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     )
+ * )
+ */
+class TarifFeatureStoreControllerDoc {}

--- a/app/OpenApi/Controllers/TarifFeature/TarifFeatureUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifFeature/TarifFeatureUpdateControllerDoc.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Put(
+ *     path="/api/tarif-features/{id}",
+ *     summary="Mettre à jour une caractéristique de tarif",
+ *     description="Met à jour le nom ou le tarif associé d'une feature existante.",
+ *     tags={"Tarif Features"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID du TarifFeature",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"name"},
+ *
+ *             @OA\Property(property="name", type="string", example="Support Premium 24/7")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TarifFeature mis à jour",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifFeatureResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TarifFeature non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="TarifFeature not found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     )
+ * )
+ */
+class TarifFeatureUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserCriteriaControllerDoc.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarif-users/search",
+ *     summary="Récupérer les TarifUsers selon des critères",
+ *     description="Retourne une collection de TarifUser filtrée selon les critères fournis. Si l'utilisateur n'est pas admin, seuls ses propres enregistrements sont renvoyés.",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par user_id (optionnel, non admin ignoré)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="tarif_id",
+ *         in="query",
+ *         description="Filtrer par tarif_id (optionnel)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=2)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Collection de TarifUser renvoyée avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifUserCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la récupération des données"))
+ *     )
+ * )
+ */
+class TarifUserCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserDestroyControllerDoc.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Delete(
+ *     path="/api/tarif-users/{id}",
+ *     summary="Supprimer un TarifUser",
+ *     description="Supprime un TarifUser par ID",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du TarifUser à supprimer",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TarifUser supprimé avec succès",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Supprimé avec succès"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TarifUser non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Not Found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la suppression"))
+ *     )
+ * )
+ */
+class TarifUserDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserIndexControllerDoc.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarif-users",
+ *     summary="Récupérer les TarifUsers selon des critères",
+ *     description="Retourne une collection de TarifUser filtrée selon les critères fournis. Si l'utilisateur n'est pas admin, seuls ses propres enregistrements sont renvoyés.",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\Parameter(
+ *         name="user_id",
+ *         in="query",
+ *         description="Filtrer par user_id (optionnel, non admin ignoré)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="tarif_id",
+ *         in="query",
+ *         description="Filtrer par tarif_id (optionnel)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=2)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Collection de TarifUser renvoyée avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifUserCollection")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la récupération des données"))
+ *     )
+ * )
+ */
+class TarifUserIndexControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserLatestByUserControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserLatestByUserControllerDoc.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarif-users/latest/{userId}",
+ *     summary="Récupérer le dernier TarifUser pour un utilisateur",
+ *     description="Retourne le dernier TarifUser actif pour l'utilisateur spécifié. Si aucun tarif n'est trouvé, renvoie null.",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\Parameter(
+ *         name="userId",
+ *         in="path",
+ *         required=true,
+ *         description="ID de l'utilisateur",
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Dernier TarifUser récupéré avec succès",
+ *
+ *         @OA\JsonContent(
+ *             oneOf={
+ *
+ *                 @OA\Schema(ref="#/components/schemas/TarifUserResource"),
+ *                 @OA\Schema(
+ *                     type="object",
+ *
+ *                     @OA\Property(property="success", type="boolean", example=true),
+ *                     @OA\Property(property="data", type="null", example=null),
+ *                     @OA\Property(property="message", type="string", example="Aucun tarif trouvé pour cet utilisateur.")
+ *                 )
+ *             }
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="Utilisateur non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Not Found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la récupération du dernier tarif"))
+ *     )
+ * )
+ */
+class TarifUserLatestByUserControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserShowControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserShowControllerDoc.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/tarif-users/{id}",
+ *     summary="Afficher un TarifUser",
+ *     description="Retourne les détails d'un TarifUser par ID",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du TarifUser",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TarifUser renvoyé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifUserResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TarifUser non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Not Found"))
+ *     )
+ * )
+ */
+class TarifUserShowControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserStoreControllerDoc.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/tarif-users",
+ *     summary="Créer un nouveau TarifUser",
+ *     description="Crée un TarifUser pour un utilisateur",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             required={"tarif_id","user_id"},
+ *
+ *             @OA\Property(property="tarif_id", type="integer", example=2),
+ *             @OA\Property(property="user_id", type="integer", example=5),
+ *             @OA\Property(property="expired_at", type="string", format="date-time", example="2025-10-25 12:00")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="TarifUser créé avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifUserResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Le tarif_id est requis"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la création"))
+ *     )
+ * )
+ */
+class TarifUserStoreControllerDoc {}

--- a/app/OpenApi/Controllers/TarifUser/TarifUserUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/TarifUser/TarifUserUpdateControllerDoc.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\OpenApi\Controllers\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Put(
+ *     path="/api/tarif-users/{id}",
+ *     summary="Mettre à jour un TarifUser",
+ *     description="Met à jour les informations d'un TarifUser existant",
+ *     tags={"TarifUsers"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du TarifUser à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="tarif_id", type="integer", example=2),
+ *             @OA\Property(property="expired_at", type="string", format="date-time", example="2025-11-25 12:00")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TarifUser mis à jour avec succès",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TarifUserResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TarifUser non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Not Found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Erreur de validation",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Le tarif_id est requis"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la mise à jour"))
+ *     )
+ * )
+ */
+class TarifUserUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/TypeCampaign/TypeCampaignCriteriaControllerDoc.php
+++ b/app/OpenApi/Controllers/TypeCampaign/TypeCampaignCriteriaControllerDoc.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\OpenApi\Controllers\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/type-campaigns/search",
+ *     summary="Récupère les TypeCampaign selon des critères",
+ *     description="Retourne une liste de TypeCampaign filtrée selon les critères passés en query. Si l'utilisateur n'est pas admin, filtrage automatique par user_id.",
+ *     tags={"TypeCampaigns"},
+ *
+ *     @OA\Parameter(
+ *         name="name",
+ *         in="query",
+ *         required=false,
+ *         description="Filtre par nom du type de campagne",
+ *
+ *         @OA\Schema(type="string", example="Marketing")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des TypeCampaign récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/TypeCampaignResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue lors de la récupération des TypeCampaign"))
+ *     )
+ * )
+ */
+class TypeCampaignCriteriaControllerDoc {}

--- a/app/OpenApi/Controllers/TypeCampaign/TypeCampaignDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/TypeCampaign/TypeCampaignDestroyControllerDoc.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\OpenApi\Controllers\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Delete(
+ *     path="/api/type-campaigns/{id}",
+ *     summary="Supprime un TypeCampaign",
+ *     description="Supprime un TypeCampaign existant par son ID. Nécessite les droits de suppression.",
+ *     tags={"TypeCampaigns"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du TypeCampaign à supprimer",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TypeCampaign supprimé avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Unauthorized")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Forbidden")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TypeCampaign non trouvé",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Not Found")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue lors de la suppression du TypeCampaign")
+ *         )
+ *     )
+ * )
+ */
+class TypeCampaignDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/TypeCampaign/TypeCampaignIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/TypeCampaign/TypeCampaignIndexControllerDoc.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\OpenApi\Controllers\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/type-campaigns",
+ *     summary="Liste tous les TypeCampaign",
+ *     description="Récupère tous les TypeCampaign pour les utilisateurs autorisés.",
+ *     tags={"TypeCampaigns"},
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des TypeCampaign",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/TypeCampaignResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TypeCampaignIndexControllerDoc {}

--- a/app/OpenApi/Controllers/TypeCampaign/TypeCampaignShowControllerDoc.php
+++ b/app/OpenApi/Controllers/TypeCampaign/TypeCampaignShowControllerDoc.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\OpenApi\Controllers\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/type-campaigns/{id}",
+ *     summary="Afficher un TypeCampaign",
+ *     description="Récupère un TypeCampaign par son ID.",
+ *     tags={"TypeCampaigns"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du TypeCampaign",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TypeCampaign trouvé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TypeCampaignResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TypeCampaign non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Not Found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TypeCampaignShowControllerDoc {}

--- a/app/OpenApi/Controllers/TypeCampaign/TypeCampaignStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/TypeCampaign/TypeCampaignStoreControllerDoc.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\OpenApi\Controllers\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/type-campaigns",
+ *     summary="Créer un TypeCampaign",
+ *     description="Crée un nouveau TypeCampaign.",
+ *     tags={"TypeCampaigns"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="name", type="string", example="Campagne marketing")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="TypeCampaign créé",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TypeCampaignResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Données invalides",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Le nom est requis"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TypeCampaignStoreControllerDoc {}

--- a/app/OpenApi/Controllers/TypeCampaign/TypeCampaignUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/TypeCampaign/TypeCampaignUpdateControllerDoc.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\OpenApi\Controllers\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Put(
+ *     path="/api/type-campaigns/{id}",
+ *     summary="Mettre à jour un TypeCampaign",
+ *     description="Met à jour un TypeCampaign existant.",
+ *     tags={"TypeCampaigns"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         required=true,
+ *         description="ID du TypeCampaign à mettre à jour",
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="name", type="string", example="Nouvelle campagne marketing")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="TypeCampaign mis à jour",
+ *
+ *         @OA\JsonContent(ref="#/components/schemas/TypeCampaignResource")
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Unauthorized"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès refusé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Forbidden"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=404,
+ *         description="TypeCampaign non trouvé",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Not Found"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Données invalides",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Le nom est requis"))
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(@OA\Property(property="message", type="string", example="Une erreur est survenue"))
+ *     )
+ * )
+ */
+class TypeCampaignUpdateControllerDoc {}

--- a/app/OpenApi/Controllers/User/ChangePasswordControllerDoc.php
+++ b/app/OpenApi/Controllers/User/ChangePasswordControllerDoc.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\OpenApi\Controllers\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/user/change-password",
+ *     summary="Changer le mot de passe d'un utilisateur authentifié",
+ *     description="Permet à l'utilisateur connecté de changer son mot de passe en fournissant l'ancien et le nouveau mot de passe.",
+ *     tags={"User"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *             required={"currentPassword","newPassword","newPassword_confirmation"},
+ *
+ *             @OA\Property(property="currentPassword", type="string", example="ancienMotDePasse123"),
+ *             @OA\Property(property="newPassword", type="string", example="nouveauMotDePasse123"),
+ *             @OA\Property(property="newPassword_confirmation", type="string", example="nouveauMotDePasse123")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Mot de passe modifié avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Mot de passe modifié avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Erreur lors du changement de mot de passe",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Mot de passe actuel incorrect.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Unauthorized")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=422,
+ *         description="Données invalides ou confirmation du mot de passe échouée",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Le champ newPassword doit être confirmé.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue")
+ *         )
+ *     )
+ * )
+ */
+class ChangePasswordControllerDoc {}

--- a/app/OpenApi/Controllers/User/UserDestroyControllerDoc.php
+++ b/app/OpenApi/Controllers/User/UserDestroyControllerDoc.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\OpenApi\Controllers\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Delete(
+ *     path="/api/user/{id}",
+ *     summary="Supprimer un utilisateur",
+ *     description="Supprime un utilisateur spécifié par son ID. L'utilisateur authentifié ne peut pas se supprimer lui-même.",
+ *     tags={"User"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'utilisateur à supprimer",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=5)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Utilisateur supprimé avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Utilisateur supprimé avec succès.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=400,
+ *         description="Tentative de suppression de son propre compte",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Vous ne pouvez pas supprimer votre propre compte.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=401,
+ *         description="Utilisateur non authentifié",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Unauthorized")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Utilisateur non autorisé à effectuer cette action",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Forbidden")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue lors de la suppression de l'utilisateur.")
+ *         )
+ *     )
+ * )
+ */
+class UserDestroyControllerDoc {}

--- a/app/OpenApi/Controllers/User/UserIndexControllerDoc.php
+++ b/app/OpenApi/Controllers/User/UserIndexControllerDoc.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\OpenApi\Controllers\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/users",
+ *     summary="Lister les utilisateurs",
+ *     description="Récupère une liste paginée des utilisateurs. Possibilité de filtrer par rôle et vérification email, et de trier par colonnes.",
+ *     tags={"User"},
+ *
+ *     @OA\Parameter(
+ *         name="role",
+ *         in="query",
+ *         description="Filtrer par rôle",
+ *         required=false,
+ *
+ *         @OA\Schema(type="string", example="admin")
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="verified",
+ *         in="query",
+ *         description="Filtrer par utilisateurs vérifiés (true/false)",
+ *         required=false,
+ *
+ *         @OA\Schema(type="boolean", example=true)
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="sort_by",
+ *         in="query",
+ *         description="Colonne de tri",
+ *         required=false,
+ *
+ *         @OA\Schema(type="string", example="created_at")
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="sort_order",
+ *         in="query",
+ *         description="Ordre de tri",
+ *         required=false,
+ *
+ *         @OA\Schema(type="string", enum={"asc","desc"}, example="desc")
+ *     ),
+ *
+ *     @OA\Parameter(
+ *         name="per_page",
+ *         in="query",
+ *         description="Nombre d'utilisateurs par page",
+ *         required=false,
+ *
+ *         @OA\Schema(type="integer", example=15)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Liste des utilisateurs récupérée avec succès",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(
+ *                 property="data",
+ *                 type="array",
+ *
+ *                 @OA\Items(ref="#/components/schemas/UserResource")
+ *             )
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=403,
+ *         description="Accès non autorisé",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="success", type="boolean", example=false),
+ *             @OA\Property(property="message", type="string", example="Accès non autorisé.")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=500,
+ *         description="Erreur serveur",
+ *
+ *         @OA\JsonContent(
+ *             type="object",
+ *
+ *             @OA\Property(property="message", type="string", example="Une erreur est survenue.")
+ *         )
+ *     )
+ * )
+ */
+class UserIndexControllerDoc {}

--- a/app/OpenApi/Controllers/User/UserShowControllerDoc.php
+++ b/app/OpenApi/Controllers/User/UserShowControllerDoc.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\OpenApi\Controllers\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Get(
+ *     path="/api/users/{id}",
+ *     summary="Afficher un utilisateur",
+ *     description="Récupère les informations d'un utilisateur spécifique",
+ *     operationId="UserShow",
+ *     tags={"Users"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'utilisateur",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", ref="#/components/schemas/UserResource")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=401, description="Non authentifié"),
+ *     @OA\Response(response=403, description="Accès non autorisé"),
+ *     @OA\Response(response=500, description="Erreur interne du serveur")
+ * )
+ */
+class UserShowControllerDoc {}

--- a/app/OpenApi/Controllers/User/UserStoreControllerDoc.php
+++ b/app/OpenApi/Controllers/User/UserStoreControllerDoc.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\OpenApi\Controllers\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Post(
+ *     path="/api/users",
+ *     summary="Créer un utilisateur",
+ *     description="Crée un nouvel utilisateur",
+ *     operationId="UserStore",
+ *     tags={"Users"},
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="name", type="string", example="John Doe"),
+ *             @OA\Property(property="email", type="string", example="john@example.com"),
+ *             @OA\Property(property="password", type="string", example="secret123"),
+ *             @OA\Property(property="role", type="string", enum={"user","admin"}, example="user")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=201,
+ *         description="Utilisateur créé avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Utilisateur créé avec succès."),
+ *             @OA\Property(property="data", ref="#/components/schemas/UserResource")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=400, description="Données invalides ou erreur"),
+ *     @OA\Response(response=401, description="Non authentifié"),
+ *     @OA\Response(response=403, description="Accès non autorisé"),
+ *     @OA\Response(response=500, description="Erreur interne du serveur")
+ * )
+ */
+class UserStoreControllerDoc {}

--- a/app/OpenApi/Controllers/User/UserUpdateControllerDoc.php
+++ b/app/OpenApi/Controllers/User/UserUpdateControllerDoc.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\OpenApi\Controllers\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Put(
+ *     path="/api/users/{id}",
+ *     summary="Mettre à jour un utilisateur",
+ *     description="Met à jour les informations d'un utilisateur existant",
+ *     operationId="UserUpdate",
+ *     tags={"Users"},
+ *
+ *     @OA\Parameter(
+ *         name="id",
+ *         in="path",
+ *         description="ID de l'utilisateur",
+ *         required=true,
+ *
+ *         @OA\Schema(type="integer", example=1)
+ *     ),
+ *
+ *     @OA\RequestBody(
+ *         required=true,
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="name", type="string", example="John Doe"),
+ *             @OA\Property(property="email", type="string", example="john@example.com"),
+ *             @OA\Property(property="password", type="string", example="secret123"),
+ *             @OA\Property(property="role", type="string", enum={"user","admin"}, example="user")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(
+ *         response=200,
+ *         description="Utilisateur mis à jour avec succès",
+ *
+ *         @OA\JsonContent(
+ *
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="message", type="string", example="Utilisateur mis à jour avec succès."),
+ *             @OA\Property(property="data", ref="#/components/schemas/UserResource")
+ *         )
+ *     ),
+ *
+ *     @OA\Response(response=400, description="Données invalides"),
+ *     @OA\Response(response=401, description="Non authentifié"),
+ *     @OA\Response(response=403, description="Accès non autorisé"),
+ *     @OA\Response(response=500, description="Erreur interne du serveur")
+ * )
+ */
+class UserUpdateControllerDoc {}

--- a/app/OpenApi/Info.php
+++ b/app/OpenApi/Info.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\OpenApi;
+
+/**
+ * @OA\Info(
+ * version="1.0.0",
+ * title="PostNova.AI – API SaaS de génération de contenus marketing",
+ * description="Spécification OpenAPI de la plateforme PostNova.AI pour créer automatiquement des contenus marketing (LinkedIn, TikTok, X).",
+ *
+ * @OA\Contact(
+ * email="hei.lisa.30@gmail.com",
+ * name="Support Equipe2 PostNova.AI"
+ * )
+ * )
+ *
+ * @OA\Server(
+ *     url=L5_SWAGGER_CONST_HOST,
+ *     description="Serveur principal"
+ * )
+ */
+class Info {}

--- a/app/OpenApi/Schemas/Campaign/CampaignResourceSchema.php
+++ b/app/OpenApi/Schemas/Campaign/CampaignResourceSchema.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\OpenApi\Schemas\Campaign;
+
+/**
+ * @OA\Schema(
+ *     schema="CampaignResource",
+ *     type="object",
+ *     title="Campaign Resource",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="Campagne de test"),
+ *     @OA\Property(property="user_id", type="integer", example=10),
+ *     @OA\Property(property="type_campaign_id", type="integer", example=3),
+ *     @OA\Property(
+ *         property="status",
+ *         type="object",
+ *         @OA\Property(property="value", type="string", example="active"),
+ *         @OA\Property(property="label", type="string", example="Active")
+ *     ),
+ *     @OA\Property(property="is_published", type="boolean", example=true),
+ *     @OA\Property(property="description", type="string", example="Description de la campagne"),
+ *     @OA\Property(
+ *         property="user",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="id", type="integer", example=10),
+ *         @OA\Property(property="name", type="string", example="Jean Dupont")
+ *     ),
+ *     @OA\Property(property="user_has_liked", type="boolean", example=true),
+ *     @OA\Property(property="user_has_shared", type="boolean", example=false),
+ *     @OA\Property(
+ *         property="type",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="id", type="integer", example=2),
+ *         @OA\Property(property="name", type="string", example="Campagne Marketing")
+ *     ),
+ *     @OA\Property(
+ *         property="dates",
+ *         type="object",
+ *         @OA\Property(property="created_at", type="string", example="2025-09-21 12:00"),
+ *         @OA\Property(property="updated_at", type="string", example="2025-09-21 12:30"),
+ *         @OA\Property(property="time_ago", type="string", example="il y a 2 heures")
+ *     ),
+ *     @OA\Property(property="images_count", type="integer", example=3),
+ *     @OA\Property(property="landing_pages_count", type="integer", example=1),
+ *     @OA\Property(property="social_posts_count", type="integer", example=5),
+ *     @OA\Property(property="total_views", type="integer", example=1000),
+ *     @OA\Property(property="total_likes", type="integer", example=50),
+ *     @OA\Property(property="total_shares", type="integer", example=20),
+ *     @OA\Property(
+ *         property="images",
+ *         type="array",
+ *
+ *         @OA\Items(
+ *             type="object",
+ *
+ *             @OA\Property(property="id", type="integer", example=1),
+ *             @OA\Property(property="url", type="string", example="https://cdn.site.com/image1.jpg"),
+ *             @OA\Property(property="alt", type="string", example="Image de la campagne"),
+ *             @OA\Property(property="is_published", type="boolean", example=true),
+ *             @OA\Property(property="created_at", type="string", example="2025-09-21 12:15")
+ *         )
+ *     )
+ * )
+ */
+class CampaignResourceSchema {}

--- a/app/OpenApi/Schemas/Campaign/PopularCampaignResourceSchema.php
+++ b/app/OpenApi/Schemas/Campaign/PopularCampaignResourceSchema.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\OpenApi\Schemas\Campaign;
+
+/**
+ * @OA\Schema(
+ *     schema="PopularCampaignResourceSchema",
+ *     type="object",
+ *     title="Popular Campaign Resource",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="Campagne populaire"),
+ *     @OA\Property(property="description", type="string", example="Description de la campagne"),
+ *     @OA\Property(property="type_campaign_id", type="integer", example=2),
+ *     @OA\Property(property="image_path", type="string", example="https://cdn.site.com/image1.jpg"),
+ *     @OA\Property(property="total_views", type="integer", example=1200),
+ *     @OA\Property(property="total_likes", type="integer", example=150)
+ * )
+ */
+class PopularCampaignResourceSchema {}

--- a/app/OpenApi/Schemas/CampaignFeatures/CampaignFeaturesResource.php
+++ b/app/OpenApi/Schemas/CampaignFeatures/CampaignFeaturesResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\OpenApi\Schemas\CampaignFeatures;
+
+/**
+ * @OA\Schema(
+ *     schema="CampaignFeaturesResource",
+ *     type="object",
+ *     title="Campaign Features Resource",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="campaign_id", type="integer", example=10),
+ *     @OA\Property(property="feature_id", type="integer", example=3)
+ * )
+ */
+class CampaignFeaturesResource {}

--- a/app/OpenApi/Schemas/CampaignInteraction/CampaignInteractionResource.php
+++ b/app/OpenApi/Schemas/CampaignInteraction/CampaignInteractionResource.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\OpenApi\Schemas\CampaignInteraction;
+
+/**
+ * @OA\Schema(
+ *     schema="CampaignInteractionResource",
+ *     type="object",
+ *     title="Campaign Interaction",
+ *     description="Représentation d'une interaction utilisateur avec une campagne",
+ *
+ *     @OA\Property(
+ *         property="id",
+ *         type="integer",
+ *         example=101
+ *     ),
+ *     @OA\Property(
+ *         property="campaign_id",
+ *         type="integer",
+ *         example=12,
+ *         description="Identifiant de la campagne"
+ *     ),
+ *     @OA\Property(
+ *         property="user_id",
+ *         type="integer",
+ *         example=45,
+ *         description="Identifiant de l’utilisateur ayant interagi"
+ *     ),
+ *     @OA\Property(
+ *         property="type",
+ *         type="string",
+ *         example="like",
+ *         description="Type d’interaction (view, like, share…)"
+ *     ),
+ *     @OA\Property(
+ *         property="views",
+ *         type="integer",
+ *         example=5,
+ *         description="Nombre de vues associées"
+ *     ),
+ *     @OA\Property(
+ *         property="likes",
+ *         type="integer",
+ *         example=1,
+ *         description="Nombre de likes associés"
+ *     ),
+ *     @OA\Property(
+ *         property="shares",
+ *         type="integer",
+ *         example=0,
+ *         description="Nombre de partages associés"
+ *     ),
+ *     @OA\Property(
+ *         property="created_at",
+ *         type="string",
+ *         format="date-time",
+ *         example="2025-09-25T12:34:56Z"
+ *     ),
+ *     @OA\Property(
+ *         property="updated_at",
+ *         type="string",
+ *         format="date-time",
+ *         example="2025-09-25T14:12:00Z"
+ *     )
+ * )
+ */
+class CampaignInteractionResource {}
+
+/**
+ * @OA\Schema(
+ *     schema="CampaignInteractionMeta",
+ *     type="object",
+ *     title="Campaign Interaction Meta",
+ *     description="Métadonnées globales sur les interactions d'une campagne",
+ *
+ *     @OA\Property(
+ *         property="total_interactions",
+ *         type="integer",
+ *         example=50,
+ *         description="Nombre total d’interactions"
+ *     ),
+ *     @OA\Property(
+ *         property="total_views",
+ *         type="integer",
+ *         example=120,
+ *         description="Nombre total de vues"
+ *     ),
+ *     @OA\Property(
+ *         property="total_likes",
+ *         type="integer",
+ *         example=30,
+ *         description="Nombre total de likes"
+ *     ),
+ *     @OA\Property(
+ *         property="total_shares",
+ *         type="integer",
+ *         example=10,
+ *         description="Nombre total de partages"
+ *     )
+ * )
+ */
+class CampaignInteractionMetaSchema {}

--- a/app/OpenApi/Schemas/CampaignTemplate/CampaignTemplateResource.php
+++ b/app/OpenApi/Schemas/CampaignTemplate/CampaignTemplateResource.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\OpenApi\Schemas\CampaignTemplate;
+
+/**
+ * @OA\Schema(
+ *     schema="CampaignTemplateResource",
+ *     type="object",
+ *     title="Campaign Template",
+ *     description="Représentation d'un modèle de campagne avec ses stats et informations détaillées",
+ *
+ *     @OA\Property(
+ *         property="id",
+ *         type="integer",
+ *         example=7,
+ *         description="Identifiant du template"
+ *     ),
+ *     @OA\Property(
+ *         property="name",
+ *         type="string",
+ *         example="Template Marketing Automatique",
+ *         description="Nom du template"
+ *     ),
+ *     @OA\Property(
+ *         property="description",
+ *         type="string",
+ *         example="Template pour campagne marketing automatisée",
+ *         description="Description du template"
+ *     ),
+ *     @OA\Property(
+ *         property="category",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="id", type="integer", example=2),
+ *         @OA\Property(property="name", type="string", example="Marketing"),
+ *         @OA\Property(property="icon", type="string", example="marketing-icon")
+ *     ),
+ *     @OA\Property(
+ *         property="type",
+ *         type="object",
+ *         nullable=true,
+ *         @OA\Property(property="id", type="integer", example=1),
+ *         @OA\Property(property="name", type="string", example="Email Campaign")
+ *     ),
+ *     @OA\Property(
+ *         property="author",
+ *         type="string",
+ *         example="John Doe",
+ *         description="Auteur du template"
+ *     ),
+ *     @OA\Property(
+ *         property="thumbnail",
+ *         type="string",
+ *         example="https://example.com/thumbnails/template7.png",
+ *         description="URL de la miniature du template"
+ *     ),
+ *     @OA\Property(
+ *         property="preview",
+ *         type="string",
+ *         example="https://example.com/previews/template7.png",
+ *         description="URL de l'aperçu du template"
+ *     ),
+ *     @OA\Property(
+ *         property="isPremium",
+ *         type="boolean",
+ *         example=true,
+ *         description="Indique si le template est premium"
+ *     ),
+ *     @OA\Property(
+ *         property="rating",
+ *         type="number",
+ *         format="float",
+ *         example=4.5,
+ *         description="Note moyenne du template"
+ *     ),
+ *     @OA\Property(
+ *         property="uses",
+ *         type="integer",
+ *         example=120,
+ *         description="Nombre de fois que le template a été utilisé"
+ *     ),
+ *     @OA\Property(
+ *         property="tags",
+ *         type="array",
+ *
+ *         @OA\Items(type="string"),
+ *         example={"marketing", "automation", "email"},
+ *         description="Tags associés au template"
+ *     ),
+ *
+ *     @OA\Property(
+ *         property="socialPosts",
+ *         type="array",
+ *
+ *         @OA\Items(
+ *             type="object",
+ *
+ *             @OA\Property(property="id", type="integer", example=101),
+ *             @OA\Property(property="content", type="string", example="Découvrez notre nouveau produit !"),
+ *             @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 12:34"),
+ *             @OA\Property(
+ *                 property="social",
+ *                 type="object",
+ *                 nullable=true,
+ *                 @OA\Property(property="id", type="integer", example=3),
+ *                 @OA\Property(property="name", type="string", example="LinkedIn")
+ *             )
+ *         )
+ *     ),
+ *     @OA\Property(
+ *         property="createdAt",
+ *         type="string",
+ *         format="date",
+ *         example="2025-09-01",
+ *         description="Date de création du template"
+ *     )
+ * )
+ */
+class CampaignTemplateResource {}

--- a/app/OpenApi/Schemas/Error400.php
+++ b/app/OpenApi/Schemas/Error400.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Error400",
+ *     type="object",
+ *     title="Requête incorrecte",
+ *     description="Les paramètres de la requête sont invalides",
+ *
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="message", type="string", example="Paramètres de requête invalides")
+ * )
+ */
+class Error400 {}

--- a/app/OpenApi/Schemas/Error401.php
+++ b/app/OpenApi/Schemas/Error401.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Error401",
+ *     type="object",
+ *     title="Non authentifié",
+ *     description="Authentification requise ou token invalide",
+ *
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="message", type="string", example="Authentification requise")
+ * )
+ */
+class Error401 {}

--- a/app/OpenApi/Schemas/Error403.php
+++ b/app/OpenApi/Schemas/Error403.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Error403",
+ *     type="object",
+ *     title="Accès refusé",
+ *     description="Permissions insuffisantes",
+ *
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="message", type="string", example="Accès non autorisé")
+ * )
+ */
+class Error403 {}

--- a/app/OpenApi/Schemas/Error422.php
+++ b/app/OpenApi/Schemas/Error422.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Error422",
+ *     type="object",
+ *     title="Erreur de validation",
+ *     description="Données de validation invalides",
+ *
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="message", type="string", example="Les données fournies sont invalides"),
+ *     @OA\Property(
+ *         property="errors",
+ *         type="object",
+ *         example={
+ *             "email": {"Le champ email est obligatoire."},
+ *             "password": {"Le mot de passe doit contenir au moins 8 caractères."}
+ *         }
+ *     )
+ * )
+ */
+class Error422 {}

--- a/app/OpenApi/Schemas/Error500.php
+++ b/app/OpenApi/Schemas/Error500.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="Error500",
+ *     type="object",
+ *     title="Erreur serveur",
+ *     description="Erreur interne du serveur",
+ *
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="message", type="string", example="Erreur interne du serveur")
+ * )
+ */
+class Error500 {}

--- a/app/OpenApi/Schemas/ErrorResponse.php
+++ b/app/OpenApi/Schemas/ErrorResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="ErrorResponse",
+ *     type="object",
+ *     title="Erreur générique",
+ *     description="Structure de réponse en cas d'erreur",
+ *
+ *     @OA\Property(property="success", type="boolean", example=false),
+ *     @OA\Property(property="message", type="string", example="Une erreur est survenue"),
+ *     @OA\Property(
+ *         property="errors",
+ *         type="object",
+ *         description="Détails des erreurs de validation (optionnel)",
+ *         example={"email": {"Le champ email est obligatoire."}}
+ *     )
+ * )
+ */
+class ErrorResponse {}

--- a/app/OpenApi/Schemas/Feature/FeatureSchemas.php
+++ b/app/OpenApi/Schemas/Feature/FeatureSchemas.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\OpenApi\Schemas\Feature;
+
+/**
+ * @OA\Schema(
+ *     schema="FeatureResource",
+ *     type="object",
+ *     title="Feature Resource",
+ *     description="Représentation d'une fonctionnalité (Feature)",
+ *
+ *     @OA\Property(property="id", type="integer", example=12),
+ *     @OA\Property(property="name", type="string", example="Nouvelle Fonctionnalité"),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 15:30")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="FeatureCollection",
+ *     type="object",
+ *     title="Feature Collection",
+ *     description="Collection de fonctionnalités",
+ *
+ *     @OA\Property(
+ *         property="data",
+ *         type="array",
+ *
+ *         @OA\Items(ref="#/components/schemas/FeatureResource")
+ *     )
+ * )
+ */
+class FeatureSchemas {}

--- a/app/OpenApi/Schemas/Image/ImageSchemas.php
+++ b/app/OpenApi/Schemas/Image/ImageSchemas.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\OpenApi\Schemas\Image;
+
+/**
+ * @OA\Schema(
+ *     schema="ImageResource",
+ *     type="object",
+ *     title="Image Resource",
+ *     description="Représentation d'une image",
+ *
+ *     @OA\Property(property="id", type="integer", example=101),
+ *     @OA\Property(property="path", type="string", example="/uploads/images/example.png"),
+ *     @OA\Property(property="is_published", type="boolean", example=true),
+ *     @OA\Property(property="campaign_id", type="integer", nullable=true, example=5),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25T15:30:00Z"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-25T15:45:00Z"),
+ *     @OA\Property(property="prompt", type="string", nullable=true, example="Image générée à partir d'une IA")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ImageCollection",
+ *     type="object",
+ *     title="Image Collection",
+ *     description="Collection d'images avec métadonnées",
+ *
+ *     @OA\Property(
+ *         property="data",
+ *         type="array",
+ *
+ *         @OA\Items(ref="#/components/schemas/ImageResource")
+ *     ),
+ *
+ *     @OA\Property(
+ *         property="meta",
+ *         type="object",
+ *         @OA\Property(property="total", type="integer", example=10)
+ *     )
+ * )
+ */
+class ImageSchemas {}

--- a/app/OpenApi/Schemas/LandingPage/LandingPageSchemas.php
+++ b/app/OpenApi/Schemas/LandingPage/LandingPageSchemas.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\OpenApi\Schemas\LandingPage;
+
+/**
+ * @OA\Schema(
+ *     schema="LandingPageResource",
+ *     type="object",
+ *     title="Landing Page Resource",
+ *     description="Représentation d'une landing page",
+ *
+ *     @OA\Property(property="id", type="integer", example=7),
+ *     @OA\Property(property="content", type="string", example="<h1>Bienvenue</h1>"),
+ *     @OA\Property(property="campaign_id", type="integer", example=3),
+ *     @OA\Property(property="is_published", type="boolean", example=true),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 15:30:00"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-25 16:00:00")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="LandingPageCollection",
+ *     type="object",
+ *     title="Landing Page Collection",
+ *     description="Collection de landing pages",
+ *
+ *     @OA\Property(
+ *         property="success",
+ *         type="boolean",
+ *         example=true
+ *     ),
+ *     @OA\Property(
+ *         property="data",
+ *         type="array",
+ *
+ *         @OA\Items(ref="#/components/schemas/LandingPageResource")
+ *     ),
+ *
+ *     @OA\Property(
+ *         property="meta",
+ *         type="object",
+ *         @OA\Property(property="total", type="integer", example=12)
+ *     )
+ * )
+ */
+class LandingPageSchemas {}

--- a/app/OpenApi/Schemas/Prompt/PromptResource.php
+++ b/app/OpenApi/Schemas/Prompt/PromptResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\OpenApi\Schemas\Prompt;
+
+/**
+ * @OA\Schema(
+ *     schema="PromptResource",
+ *     type="object",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="content", type="string", example="Créer un prompt pour campagne X"),
+ *     @OA\Property(property="campaign_id", type="integer", example=5),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 15:30:00"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-25 15:30:00")
+ * )
+ */
+class PromptResource {}

--- a/app/OpenApi/Schemas/Social/SocialResource.php
+++ b/app/OpenApi/Schemas/Social/SocialResource.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\OpenApi\Schemas\Social;
+
+/**
+ * @OA\Schema(
+ *     schema="SocialResource",
+ *     type="object",
+ *     title="Social Resource",
+ *     description="Représente un post social",
+ *
+ *     @OA\Property(property="name", type="string", example="Nom du post social")
+ * )
+ */
+class SocialResource {}

--- a/app/OpenApi/Schemas/SocialPost/SocialPostResource.php
+++ b/app/OpenApi/Schemas/SocialPost/SocialPostResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\OpenApi\Schemas\SocialPost;
+
+/**
+ * @OA\Schema(
+ *     schema="SocialPostResource",
+ *     type="object",
+ *     title="SocialPost Resource",
+ *     description="Représente un post social",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="content", type="string", example="Contenu du post social"),
+ *     @OA\Property(property="is_published", type="boolean", example=true),
+ *     @OA\Property(property="social_id", type="integer", example=2),
+ *     @OA\Property(property="campaign_id", type="integer", example=3),
+ *     @OA\Property(property="prompt_id", type="integer", example=4),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 12:34:56"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-25 12:34:56"),
+ *     @OA\Property(
+ *         property="social",
+ *         type="object",
+ *         nullable=true,
+ *         description="Relation chargée du social",
+ *         example={"id":2, "name":"Nom du social"}
+ *     ),
+ *     @OA\Property(
+ *         property="campaign",
+ *         type="object",
+ *         nullable=true,
+ *         description="Relation chargée de la campagne",
+ *         example={"id":3, "title":"Nom de la campagne"}
+ *     )
+ * )
+ */
+class SocialPostResource {}

--- a/app/OpenApi/Schemas/Tarif/TarifResource.php
+++ b/app/OpenApi/Schemas/Tarif/TarifResource.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\OpenApi\Schemas\Tarif;
+
+/**
+ * @OA\Schema(
+ *     schema="TarifResource",
+ *     type="object",
+ *     description="Représente un tarif",
+ *
+ *     @OA\Property(
+ *         property="id",
+ *         type="integer",
+ *         description="ID du tarif",
+ *         example=1
+ *     ),
+ *     @OA\Property(
+ *         property="name",
+ *         type="string",
+ *         description="Nom du tarif",
+ *         example="Pro"
+ *     ),
+ *     @OA\Property(
+ *         property="amount",
+ *         type="number",
+ *         format="float",
+ *         description="Montant du tarif",
+ *         example=29.99
+ *     ),
+ *     @OA\Property(
+ *         property="max_limit",
+ *         type="integer",
+ *         description="Limite maximale associée au tarif",
+ *         example=50
+ *     )
+ * )
+ */
+class TarifResource {}

--- a/app/OpenApi/Schemas/TarifFeature/TarifFeatureResource.php
+++ b/app/OpenApi/Schemas/TarifFeature/TarifFeatureResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\OpenApi\Schemas\TarifFeature;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="TarifFeatureResource",
+ *     title="Tarif Feature",
+ *     description="Représentation d'une fonctionnalité liée à un tarif",
+ *     type="object",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="tarif_id", type="integer", example=5),
+ *     @OA\Property(property="name", type="string", example="Support Premium"),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 12:30"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-25 12:30")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="TarifFeatureCollection",
+ *     title="Tarif Feature Collection",
+ *     type="object",
+ *
+ *     @OA\Property(
+ *         property="data",
+ *         type="array",
+ *
+ *         @OA\Items(ref="#/components/schemas/TarifFeatureResource")
+ *     )
+ * )
+ */
+class TarifFeatureResource {}

--- a/app/OpenApi/Schemas/TarifUser/TarifUserCollection.php
+++ b/app/OpenApi/Schemas/TarifUser/TarifUserCollection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\OpenApi\Schemas\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="TarifUserCollection",
+ *     type="object",
+ *
+ *     @OA\Property(
+ *         property="data",
+ *         type="array",
+ *
+ *         @OA\Items(ref="#/components/schemas/TarifUserResource")
+ *     )
+ * )
+ */
+class TarifUserCollection {}

--- a/app/OpenApi/Schemas/TarifUser/TarifUserResource.php
+++ b/app/OpenApi/Schemas/TarifUser/TarifUserResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\OpenApi\Schemas\TarifUser;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="TarifUserResource",
+ *     type="object",
+ *     title="TarifUser",
+ *     description="Représentation d'un TarifUser",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="tarif_id", type="integer", example=2),
+ *     @OA\Property(property="user_id", type="integer", example=5),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 12:00"),
+ *     @OA\Property(property="expired_at", type="string", format="date-time", example="2025-10-25 12:00"),
+ *     @OA\Property(
+ *         property="tarif",
+ *         type="object",
+ *         @OA\Property(property="id", type="integer", example=2),
+ *         @OA\Property(property="name", type="string", example="Premium"),
+ *         @OA\Property(property="amount", type="number", format="float", example=99.99),
+ *         @OA\Property(property="max_limit", type="integer", example=100)
+ *     )
+ * )
+ */
+class TarifUserResource {}

--- a/app/OpenApi/Schemas/TypeCampaign/TypeCampaignResource.php
+++ b/app/OpenApi/Schemas/TypeCampaign/TypeCampaignResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\OpenApi\Schemas\TypeCampaign;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="TypeCampaignResource",
+ *     type="object",
+ *     title="TypeCampaignResource",
+ *     description="Représentation d'un TypeCampaign",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="Marketing"),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-25 14:30"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-25 14:30")
+ * )
+ */
+class TypeCampaignResource {}

--- a/app/OpenApi/Schemas/User.php
+++ b/app/OpenApi/Schemas/User.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+/**
+ * @OA\Schema(
+ *     schema="User",
+ *     type="object",
+ *     title="User",
+ *     description="Représentation d'un utilisateur",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="John Doe"),
+ *     @OA\Property(property="email", type="string", format="email", example="john.doe@example.com"),
+ *     @OA\Property(property="role", type="string", example="user"),
+ *     @OA\Property(property="email_verified_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ */
+class User {}

--- a/app/OpenApi/Schemas/User/UserResource.php
+++ b/app/OpenApi/Schemas/User/UserResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\OpenApi\Schemas\User;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="UserResource",
+ *     type="object",
+ *     title="User Resource",
+ *     description="Représentation d'un utilisateur",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="name", type="string", example="John Doe"),
+ *     @OA\Property(property="email", type="string", example="john@example.com"),
+ *     @OA\Property(property="role", type="string", example="admin"),
+ *     @OA\Property(property="email_verified_at", type="string", format="date-time", example="2025-09-25T19:00:00Z"),
+ *     @OA\Property(property="created_at", type="string", format="date-time", example="2025-09-01T12:00:00Z"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", example="2025-09-20T10:00:00Z")
+ * )
+ */
+class UserResource {}

--- a/app/Services/CloudinaryService.php
+++ b/app/Services/CloudinaryService.php
@@ -14,19 +14,18 @@ class CloudinaryService
         $this->cloudinary = new Cloudinary([
             'cloud' => [
                 'cloud_name' => config('services.cloudinary.cloud_name'),
-                'api_key'    => config('services.cloudinary.api_key'),
+                'api_key' => config('services.cloudinary.api_key'),
                 'api_secret' => config('services.cloudinary.api_secret'),
-            ]
+            ],
         ]);
     }
 
     /**
      * Upload une image vers Cloudinary.
      *
-     * @param string|mixed $imageData Chemin, base64 ou données binaires
-     * @param string $folder Dossier Cloudinary
-     * @param string|null $publicId Identifiant personnalisé
-     * @return array
+     * @param  string|mixed  $imageData  Chemin, base64 ou données binaires
+     * @param  string  $folder  Dossier Cloudinary
+     * @param  string|null  $publicId  Identifiant personnalisé
      */
     public function uploadImage($imageData, string $folder = 'ai-images', ?string $publicId = null): array
     {
@@ -43,24 +42,24 @@ class CloudinaryService
             } elseif (is_string($imageData) && str_starts_with($imageData, 'data:image')) {
                 $file = $imageData;
             } else {
-                $file = 'data:image/jpeg;base64,' . base64_encode($imageData);
+                $file = 'data:image/jpeg;base64,'.base64_encode($imageData);
             }
 
             $result = $this->cloudinary->uploadApi()->upload($file, $options);
 
             return [
-                'success'   => true,
-                'url'       => $result['secure_url'],
+                'success' => true,
+                'url' => $result['secure_url'],
                 'public_id' => $result['public_id'],
-                'format'    => $result['format'],
-                'bytes'     => $result['bytes']
+                'format' => $result['format'],
+                'bytes' => $result['bytes'],
             ];
         } catch (\Exception $e) {
-            Log::error('Cloudinary upload failed: ' . $e->getMessage());
+            Log::error('Cloudinary upload failed: '.$e->getMessage());
 
             return [
                 'success' => false,
-                'error'   => $e->getMessage()
+                'error' => $e->getMessage(),
             ];
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "php": "^8.2",
         "cloudinary/cloudinary_php": "^3.1",
+        "darkaonline/l5-swagger": "^9.0",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ff61f7e22ef74552018f1d9c6bc0cd6",
+    "content-hash": "b5b93d531e032c6081b2dbad4182797e",
     "packages": [
         {
             "name": "brick/math",
@@ -260,6 +260,87 @@
             "time": "2025-02-03T11:14:03+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "2c26427f8c41db8e72232415e7287313e6b6a2e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/2c26427f8c41db8e72232415e7287313e6b6a2e2",
+                "reference": "2c26427f8c41db8e72232415e7287313e6b6a2e2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^12.0 || ^11.0",
+                "php": "^8.2",
+                "swagger-api/swagger-ui": ">=5.18.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^5.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/9.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-28T06:25:02+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -333,6 +414,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2777,6 +2934,55 @@
             "time": "2025-08-21T11:53:16+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3463,6 +3669,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "26e6d3cce2a49195681116c97318b2a38c06e21c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/26e6d3cce2a49195681116c97318b2a38c06e21c",
+                "reference": "26e6d3cce2a49195681116c97318b2a38c06e21c",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.29.0"
+            },
+            "time": "2025-09-09T14:04:45+00:00"
         },
         {
             "name": "symfony/clock",
@@ -5943,6 +6210,82 @@
             "time": "2025-08-13T11:49:31+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
+                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-27T11:34:33+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.3.0",
             "source": {
@@ -6212,6 +6555,92 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "d8fa9dc4c3b2fc8651ae780021bb9719b1e63d40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/d8fa9dc4c3b2fc8651ae780021bb9719b1e63d40",
+                "reference": "d8fa9dc4c3b2fc8651ae780021bb9719b1e63d40",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=7.4",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^9.0",
+                "rector/rector": "^1.0 || ^2.0",
+                "vimeo/psalm": "^4.30 || ^5.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/5.3.2"
+            },
+            "time": "2025-08-25T21:57:16+00:00"
         }
     ],
     "packages-dev": [
@@ -9943,82 +10372,6 @@
                 }
             ],
             "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d4f4a66866fe2451f61296924767280ab5732d9d",
-                "reference": "d4f4a66866fe2451f61296924767280ab5732d9d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.3"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-08-27T11:34:33+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,279 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'PostNova.AI API', // Modifier le titre
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                //                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 * AJOUTER le chemin vers le dossier Swagger
+                 */
+                'annotations' => [
+                    base_path('app'),
+                    base_path('app/OpenApi'),
+                    base_path('app'),
+                    base_path('app/Http/Controllers'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            'annotations' => [
+                base_path('app/OpenApi'),
+            ],
+
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => base_path('docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                // Configuration pour Laravel Sanctum
+                'sanctum' => [
+                    'type' => 'apiKey',
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization',
+                    'in' => 'header',
+                ],
+            ],
+            'security' => [
+                // Appliquer la sécurité par défaut
+                [
+                    'sanctum' => [],
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true),
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://localhost:8000'),
+        ],
+    ],
+];

--- a/docs/api-docs.json
+++ b/docs/api-docs.json
@@ -1,0 +1,12786 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "PostNova.AI – API SaaS de génération de contenus marketing",
+        "description": "Spécification OpenAPI de la plateforme PostNova.AI pour créer automatiquement des contenus marketing (LinkedIn, TikTok, X).",
+        "contact": {
+            "name": "Support Equipe2 PostNova.AI",
+            "email": "hei.lisa.30@gmail.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8000",
+            "description": "Serveur principal"
+        }
+    ],
+    "paths": {
+        "/api/auth/login": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Connexion utilisateur",
+                "description": "Authentifie un utilisateur et retourne un token JWT",
+                "operationId": "02395a73cadbcda572185a01c3cd2f4f",
+                "requestBody": {
+                    "description": "Données de connexion",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "email",
+                                    "password"
+                                ],
+                                "properties": {
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "john.doe@example.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "format": "password",
+                                        "example": "Password123!"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Connexion réussie",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Connexion réussie."
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "user": {
+                                                    "$ref": "#/components/schemas/User"
+                                                },
+                                                "token": {
+                                                    "type": "string",
+                                                    "example": "1|a1b2c3d4e5f6g7h8i9j0..."
+                                                },
+                                                "token_type": {
+                                                    "type": "string",
+                                                    "example": "Bearer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Email ou mot de passe invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Email ou mot de passe invalide"
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "nullable": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/logout": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Déconnexion utilisateur",
+                "operationId": "88e8ba244c99f969290e8a8550cf839f",
+                "responses": {
+                    "200": {
+                        "description": "Déconnexion réussie",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Déconnexion réussie."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/me": {
+            "get": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Récupérer les informations de l'utilisateur connecté",
+                "operationId": "9cdf6d7f0d1076f420e43b051bcb065c",
+                "responses": {
+                    "200": {
+                        "description": "Informations utilisateur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/refresh-token": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Rafraîchir le token",
+                "operationId": "c30aadf3ff6455d85fd93b1fb7ac4603",
+                "responses": {
+                    "200": {
+                        "description": "Token rafraîchi",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Token rafraîchi"
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/register": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Inscription utilisateur",
+                "operationId": "c2ccd6d98f1383d0449627059ecd0c4a",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "email",
+                                    "password",
+                                    "password_confirmation"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "John Doe"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "john.doe@example.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "format": "password",
+                                        "example": "Password123!"
+                                    },
+                                    "password_confirmation": {
+                                        "type": "string",
+                                        "format": "password",
+                                        "example": "Password123!"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Inscription réussie",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Inscription réussie"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "user": {
+                                                    "$ref": "#/components/schemas/User"
+                                                },
+                                                "token": {
+                                                    "type": "string",
+                                                    "example": "1|a1b2c3d4e5f6..."
+                                                },
+                                                "token_type": {
+                                                    "type": "string",
+                                                    "example": "Bearer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error422"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/campaigns/type/{typeId}": {
+            "get": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Lister les campagnes par type",
+                "description": "Retourne les campagnes correspondant à un type spécifique. Les campagnes sont filtrées selon les permissions de l'utilisateur connecté.",
+                "operationId": "2e8b9842ad77c77b249924447b26b9a8",
+                "parameters": [
+                    {
+                        "name": "typeId",
+                        "in": "path",
+                        "description": "ID du type de campagne",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 2
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Campagnes récupérées avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 3
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Type de campagne introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns/search": {
+            "get": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Lister les campagnes selon des critères",
+                "description": "Retourne les campagnes filtrées selon les critères passés en query params.",
+                "operationId": "16756c03de40dbd28d7ce08a0b670428",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filtrer par statut de campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "active"
+                        }
+                    },
+                    {
+                        "name": "type_campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par type de campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 2
+                        }
+                    },
+                    {
+                        "name": "is_published",
+                        "in": "query",
+                        "description": "Filtrer par publication",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "example": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Campagnes récupérées avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "La requête est invalide ou mal formée",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de consulter ces campagnes",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur de serveur est survenue"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns/{id}": {
+            "get": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Afficher une campagne",
+                "description": "Retourne les détails d'une campagne spécifique par son ID.",
+                "operationId": "5039bf095f984717e4bf75f92d9a5d13",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la campagne",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails de la campagne récupérés avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé à accéder à cette ressource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Campagne introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Mettre à jour une campagne",
+                "description": "Met à jour une campagne existante appartenant à l’utilisateur connecté (ou accessible par un admin).",
+                "operationId": "509d20710d9307eeb1a18100a7140201",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la campagne à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Données à mettre à jour pour la campagne",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "description",
+                                    "type_campaign_id"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "maxLength": 255,
+                                        "example": "Nom mis à jour de la campagne"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "maxLength": 1000,
+                                        "example": "Nouvelle description de la campagne"
+                                    },
+                                    "type_campaign_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "example": "active",
+                                        "nullable": true
+                                    },
+                                    "is_published": {
+                                        "type": "boolean",
+                                        "example": true
+                                    },
+                                    "social_posts": {
+                                        "description": "Liste optionnelle de posts associés",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "example": "Contenu modifié d’un post social"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Campagne mise à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Campagne introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides.",
+                                    "errors": {
+                                        "name": [
+                                            "Le nom de la campaign est obligatoire."
+                                        ],
+                                        "description": [
+                                            "La description de la campagne ne dépasse pas 1000 caractères"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Supprimer une campagne",
+                "description": "Supprime une campagne existante appartenant à l’utilisateur connecté (ou accessible par un admin).",
+                "operationId": "2423d69c99369440246dff4532a4d26c",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la campagne à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Campagne supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "La requête est invalide",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns/generate-name": {
+            "post": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Générer une campagne depuis une description",
+                "description": "Crée une campagne basée sur la description fournie et retourne la campagne générée.",
+                "operationId": "0b639227e5fab199cbc953d81bab0bc7",
+                "requestBody": {
+                    "description": "Données pour générer la campagne",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "description",
+                                    "type_campaign_id",
+                                    "user_id"
+                                ],
+                                "properties": {
+                                    "description": {
+                                        "type": "string",
+                                        "example": "Nouvelle campagne marketing"
+                                    },
+                                    "type_campaign_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "user_id": {
+                                        "type": "integer",
+                                        "example": 10
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Campagne générée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "campaign": {
+                                            "description": "Campagne générée",
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 15
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Campagne générée automatiquement"
+                                                },
+                                                "description": {
+                                                    "type": "string",
+                                                    "example": "Nouvelle campagne marketing"
+                                                },
+                                                "type_campaign_id": {
+                                                    "type": "integer",
+                                                    "example": 2
+                                                },
+                                                "user_id": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "created"
+                                                },
+                                                "is_published": {
+                                                    "type": "boolean",
+                                                    "example": false
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "La requête est invalide ou mal formée",
+                                    "errors": {
+                                        "description": [
+                                            "Le champ description est obligatoire."
+                                        ],
+                                        "type_campaign_id": [
+                                            "Type de campagne invalide."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides.",
+                                    "errors": {
+                                        "description": [
+                                            "Le champ description est obligatoire."
+                                        ],
+                                        "user_id": [
+                                            "Utilisateur inexistant."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns": {
+            "get": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Lister les campagnes",
+                "description": "Retourne toutes les campagnes (si admin) ou celles de l’utilisateur connecté.",
+                "operationId": "bd90d8c4fcb60dc0d4bd593a520df74c",
+                "responses": {
+                    "200": {
+                        "description": "Liste des campagnes récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé à accéder à cette ressource",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Créer une campagne",
+                "description": "Crée une nouvelle campagne pour l’utilisateur connecté.",
+                "operationId": "de192e4e5da23d069fb089f061cae012",
+                "requestBody": {
+                    "description": "Données nécessaires pour créer une campagne",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "description",
+                                    "type_campaign_id"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "maxLength": 255,
+                                        "example": "Nouvelle campagne marketing"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "maxLength": 1000,
+                                        "example": "Description complète de la campagne"
+                                    },
+                                    "type_campaign_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "example": "created",
+                                        "nullable": true
+                                    },
+                                    "is_published": {
+                                        "type": "boolean",
+                                        "example": false
+                                    },
+                                    "social_posts": {
+                                        "description": "Liste optionnelle de posts associés",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "example": "Contenu d’un post social"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Campagne créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides.",
+                                    "errors": {
+                                        "name": [
+                                            "Le nom de la campagne est obligatoire."
+                                        ],
+                                        "description": [
+                                            "La description de la campagne est obligatoire."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns/template": {
+            "post": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Créer une campagne à partir d'un template",
+                "description": "Crée une nouvelle campagne en utilisant un template existant et crée éventuellement des social posts associés.",
+                "operationId": "dcc43de0afcc38841f8ca8550ca4c5dd",
+                "requestBody": {
+                    "description": "Données nécessaires pour créer la campagne avec template",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "description",
+                                    "type_campaign_id",
+                                    "template_id"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "maxLength": 255,
+                                        "example": "Nouvelle campagne avec template"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "maxLength": 1000,
+                                        "example": "Description complète de la campagne"
+                                    },
+                                    "type_campaign_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "template_id": {
+                                        "type": "integer",
+                                        "example": 5
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "example": "created",
+                                        "nullable": true
+                                    },
+                                    "is_published": {
+                                        "type": "boolean",
+                                        "example": false
+                                    },
+                                    "social_posts": {
+                                        "description": "Liste optionnelle de posts sociaux à créer avec la campagne",
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "content": {
+                                                    "type": "string",
+                                                    "example": "Contenu du post social"
+                                                },
+                                                "social": {
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer",
+                                                            "example": 1
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Campagne créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides",
+                                    "errors": {
+                                        "name": [
+                                            "Le nom de la campagne est obligatoire."
+                                        ],
+                                        "description": [
+                                            "La description est obligatoire."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns/user/{userId}": {
+            "get": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Récupérer les campagnes d'un utilisateur",
+                "description": "Retourne la liste des campagnes appartenant à un utilisateur spécifique",
+                "operationId": "8e69873fcebc30bfd9fe158e731e6508",
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Campagnes récupérées avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Utilisateur non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaigns/popular/content": {
+            "get": {
+                "tags": [
+                    "Campaigns"
+                ],
+                "summary": "Récupérer les campagnes populaires",
+                "description": "Retourne la liste des campagnes populaires avec leurs statistiques",
+                "operationId": "5b3bc3638a88567652213b601682fa6b",
+                "responses": {
+                    "200": {
+                        "description": "Liste des campagnes populaires récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/PopularCampaignResourceSchema"
+                                            }
+                                        },
+                                        "totals": {
+                                            "properties": {
+                                                "total_views": {
+                                                    "type": "integer",
+                                                    "example": 5000
+                                                },
+                                                "total_likes": {
+                                                    "type": "integer",
+                                                    "example": 350
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-features/search": {
+            "get": {
+                "tags": [
+                    "CampaignFeatures"
+                ],
+                "summary": "Récupérer les CampaignFeatures selon des critères",
+                "description": "Retourne la liste des CampaignFeatures filtrée par les critères passés en query. Les utilisateurs non admin ne voient que leurs propres CampaignFeatures.",
+                "operationId": "e3fbdc9bef2982b6d6691ab64bc61607",
+                "parameters": [
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de campagne",
+                        "schema": {
+                            "type": "integer",
+                            "example": 10
+                        }
+                    },
+                    {
+                        "name": "feature_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de feature",
+                        "schema": {
+                            "type": "integer",
+                            "example": 3
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des CampaignFeatures récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignFeaturesResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-features/{id}": {
+            "get": {
+                "tags": [
+                    "CampaignFeatures"
+                ],
+                "summary": "Afficher une CampaignFeature",
+                "description": "Retourne les détails d'une CampaignFeature spécifique par son ID.",
+                "operationId": "1b7d874e362e45be0b2a6d1719e290ff",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la CampaignFeature à récupérer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CampaignFeature récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignFeaturesResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "CampaignFeature introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "CampaignFeatures"
+                ],
+                "summary": "Mettre à jour une CampaignFeature",
+                "description": "Met à jour les informations d'une CampaignFeature existante.",
+                "operationId": "81adae49d762688649a081c94f0ddfc6",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la CampaignFeature à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Données à mettre à jour pour la CampaignFeature",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 10
+                                    },
+                                    "feature_id": {
+                                        "type": "integer",
+                                        "example": 3
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "CampaignFeature mise à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignFeaturesResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "CampaignFeatures"
+                ],
+                "summary": "Supprimer une CampaignFeature",
+                "description": "Supprime une CampaignFeature par son ID. Seul l'utilisateur autorisé peut effectuer cette action.",
+                "operationId": "7115f34085bb1d73673d5be079bd8391",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la CampaignFeature à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CampaignFeature supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "CampaignFeature introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-features": {
+            "get": {
+                "tags": [
+                    "CampaignFeatures"
+                ],
+                "summary": "Lister toutes les CampaignFeatures",
+                "description": "Retourne la liste complète des CampaignFeatures. Les utilisateurs non admin ne voient que leurs propres CampaignFeatures.",
+                "operationId": "getCampaignFeatures",
+                "parameters": [
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de campagne",
+                        "schema": {
+                            "type": "integer",
+                            "example": 10
+                        }
+                    },
+                    {
+                        "name": "feature_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de feature",
+                        "schema": {
+                            "type": "integer",
+                            "example": 3
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des CampaignFeatures récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignFeaturesResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "CampaignFeatures"
+                ],
+                "summary": "Créer une nouvelle CampaignFeature",
+                "description": "Crée une nouvelle CampaignFeature pour une campagne spécifique.",
+                "operationId": "createCampaignFeature",
+                "requestBody": {
+                    "description": "Données nécessaires pour créer une CampaignFeature",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "campaign_id",
+                                    "feature_id"
+                                ],
+                                "properties": {
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 10
+                                    },
+                                    "feature_id": {
+                                        "type": "integer",
+                                        "example": 3
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "CampaignFeature créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignFeaturesResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides",
+                                    "errors": {
+                                        "campaign_id": [
+                                            "La campagne spécifiée est introuvable."
+                                        ],
+                                        "feature_id": [
+                                            "La fonctionnalité sélectionnée est invalide."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-interactions/search": {
+            "get": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Lister les interactions d'une campagne selon des critères",
+                "description": "Récupère une liste des interactions (vues, likes, partages, etc.) filtrées par critères fournis en query params.",
+                "operationId": "3e1b8da1a5e6c1b50eee30f62f924721",
+                "parameters": [
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par identifiant de la campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    },
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par identifiant de l’utilisateur",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 45
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Type d’interaction (view, like, share…)",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "like"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des interactions trouvées selon les critères",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignInteractionResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total_interactions": {
+                                                    "type": "integer",
+                                                    "example": 50
+                                                },
+                                                "total_views": {
+                                                    "type": "integer",
+                                                    "example": 1200
+                                                },
+                                                "total_likes": {
+                                                    "type": "integer",
+                                                    "example": 300
+                                                },
+                                                "total_shares": {
+                                                    "type": "integer",
+                                                    "example": 75
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-interactions/delete": {
+            "delete": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Supprimer une interaction par campagne et utilisateur",
+                "description": "Supprime une interaction spécifique associée à un utilisateur et une campagne.\n *     Nécessite que la combinaison (campaign_id, user_id) existe.",
+                "operationId": "d21496e4340a1f41529e73c251a69be8",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "campaign_id",
+                                    "user_id"
+                                ],
+                                "properties": {
+                                    "campaign_id": {
+                                        "description": "Identifiant de la campagne",
+                                        "type": "integer",
+                                        "example": 12
+                                    },
+                                    "user_id": {
+                                        "description": "Identifiant de l’utilisateur",
+                                        "type": "integer",
+                                        "example": 45
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Interaction supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "message": "Interaction supprimée avec succès"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Aucune interaction trouvée pour ce couple campaign_id / user_id",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "message": "Aucune interaction trouvée pour ce couple campaign_id / user_id"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide (paramètres manquants ou invalides)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "error": "Le champ campaign_id est requis et doit être un entier valide"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "error": "Unauthenticated"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "error": "Vous n’avez pas la permission de supprimer cette interaction"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "error": "Erreur interne du serveur, veuillez réessayer plus tard"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/campaign-interactions/{id}": {
+            "get": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Afficher une interaction spécifique",
+                "description": "Retourne les détails d'une interaction utilisateur avec une campagne.",
+                "operationId": "e1c97de4bfa005e30d2c216cc43d5513",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Identifiant de l'interaction",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 101
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Interaction récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/components/schemas/CampaignInteractionResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Mettre à jour une interaction existante",
+                "description": "Met à jour les informations d'une interaction spécifique (like, view, share, etc.) d'une campagne.",
+                "operationId": "83ffe30fa66ff45119a0182f502b14da",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'interaction à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 101
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Données de l'interaction à mettre à jour",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "example": "share"
+                                    },
+                                    "likes": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "views": {
+                                        "type": "integer",
+                                        "example": 15
+                                    },
+                                    "shares": {
+                                        "type": "integer",
+                                        "example": 3
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Interaction mise à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CampaignInteractionResource"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides",
+                                    "errors": {
+                                        "likes": [
+                                            "Le nombre de likes doit être un entier positif."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Supprimer une interaction par ID",
+                "description": "Supprime une interaction spécifique grâce à son identifiant unique.",
+                "operationId": "f35d5c243e3390bfc5473ee36602a97b",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Identifiant de l’interaction",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 101
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Interaction supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                                "example": {
+                                    "message": "Interaction supprimée avec succès"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Interaction non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                                "example": {
+                                    "error": "Aucune interaction trouvée avec cet identifiant"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                                "example": {
+                                    "error": "Unauthenticated"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                                "example": {
+                                    "error": "Vous n’avez pas la permission de supprimer cette interaction"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                                "example": {
+                                    "error": "Erreur interne du serveur, veuillez réessayer plus tard"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/campaign-interactions": {
+            "get": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Lister toutes les interactions",
+                "description": "Retourne la liste complète des interactions disponibles.",
+                "operationId": "0f5fe25ed6c9560143011581fdd3a7d8",
+                "responses": {
+                    "200": {
+                        "description": "Liste des interactions récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignInteractionResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 120
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Créer une nouvelle interaction pour une campagne",
+                "description": "Crée une interaction (like, view, share, etc.) pour une campagne spécifique.",
+                "operationId": "0d88ae939731e1a172b5eaf8a2c203aa",
+                "requestBody": {
+                    "description": "Données de l'interaction à créer",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "campaign_id",
+                                    "user_id",
+                                    "type"
+                                ],
+                                "properties": {
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 12
+                                    },
+                                    "user_id": {
+                                        "type": "integer",
+                                        "example": 45
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "example": "like"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Interaction créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CampaignInteractionResource"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides",
+                                    "errors": {
+                                        "type": [
+                                            "Le champ type doit être 'like', 'view' ou 'share'."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-interactions/{interactionId}/like": {
+            "post": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Ajouter un like à une interaction",
+                "description": "Incrémente le compteur de likes pour une interaction spécifique.",
+                "operationId": "8075fab4c221b05e60f37654e6a34eb8",
+                "parameters": [
+                    {
+                        "name": "interactionId",
+                        "in": "path",
+                        "description": "Identifiant de l'interaction",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 101
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Like ajouté avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "message": "Like ajouté avec succès"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Impossible d'ajouter un like",
+                                    "errors": {
+                                        "interactionId": [
+                                            "L'identifiant fourni est invalide."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-interactions/{campaignId}/stats": {
+            "get": {
+                "tags": [
+                    "Campaign Interactions"
+                ],
+                "summary": "Récupérer les statistiques d'interactions d'une campagne",
+                "description": "Retourne le nombre total de likes, vues et partages pour une campagne spécifique.",
+                "operationId": "288da0b1db6f40ba97b0043b1077e7c7",
+                "parameters": [
+                    {
+                        "name": "campaignId",
+                        "in": "path",
+                        "description": "Identifiant de la campagne",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Statistiques récupérées avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "likes": 120,
+                                    "views": 1500,
+                                    "shares": 45
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-templates": {
+            "get": {
+                "tags": [
+                    "Campaign Templates"
+                ],
+                "summary": "Lister tous les modèles de campagnes avec stats",
+                "description": "Retourne la liste de tous les modèles de campagnes avec le rating et le nombre d'utilisations.",
+                "operationId": "68c38799d766102e5b705322c6f2822d",
+                "responses": {
+                    "200": {
+                        "description": "Liste des templates récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/CampaignTemplateResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-templates/{id}": {
+            "get": {
+                "tags": [
+                    "Campaign Templates"
+                ],
+                "summary": "Récupérer un modèle de campagne spécifique avec stats",
+                "description": "Retourne un modèle de campagne avec ses statistiques (rating, nombre d'utilisations).",
+                "operationId": "8ae915c1acc4c6ae9802e941fc8e7256",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du template de campagne",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Template récupéré avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CampaignTemplateResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Template introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/categories": {
+            "get": {
+                "tags": [
+                    "Campaign Templates"
+                ],
+                "summary": "Récupérer la liste des catégories",
+                "description": "Retourne toutes les catégories disponibles avec leurs icônes.",
+                "operationId": "2165556c1747769e899a825592d1ed05",
+                "responses": {
+                    "200": {
+                        "description": "Liste des catégories récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "name": {
+                                                "description": "Nom de la catégorie",
+                                                "type": "string",
+                                                "example": "Marketing"
+                                            },
+                                            "icon": {
+                                                "description": "Nom ou chemin de l'icône",
+                                                "type": "string",
+                                                "example": "marketing-icon"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/campaign-templates/{templateId}/rating": {
+            "post": {
+                "tags": [
+                    "Campaign Templates"
+                ],
+                "summary": "Ajouter ou mettre à jour le rating d'un template",
+                "description": "Permet à un utilisateur de créer ou modifier son rating pour un template donné.",
+                "operationId": "17bf227bd53a765bc0bf10db818732f4",
+                "parameters": [
+                    {
+                        "name": "templateId",
+                        "in": "path",
+                        "description": "ID du template",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "rating": {
+                                        "type": "number",
+                                        "example": 4.5
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Rating enregistré avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": true,
+                                    "message": "Rating enregistré avec succès",
+                                    "data": {
+                                        "template_id": 7,
+                                        "user_id": 12,
+                                        "rating": 4.5
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Rating invalide ou manquant"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation des champs",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides.",
+                                    "errors": {
+                                        "rating": [
+                                            "Le champ rating doit être un nombre entre 0 et 5."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/dashboard/indicators/{userId}": {
+            "get": {
+                "tags": [
+                    "Dashboard"
+                ],
+                "summary": "Récupérer les indicateurs du dashboard pour un utilisateur",
+                "description": "Retourne les statistiques des campagnes et interactions d'un utilisateur, y compris les indicateurs globaux et ceux venant d'autres utilisateurs.",
+                "operationId": "3189df42c267a83950415e5dc949dd6a",
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "Identifiant de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 45
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Indicateurs récupérés avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "totalCampaigns": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                },
+                                                "totalViews": {
+                                                    "type": "integer",
+                                                    "example": 1200
+                                                },
+                                                "totalLikes": {
+                                                    "type": "integer",
+                                                    "example": 300
+                                                },
+                                                "totalShares": {
+                                                    "type": "integer",
+                                                    "example": 75
+                                                },
+                                                "engagementRate": {
+                                                    "type": "number",
+                                                    "format": "float",
+                                                    "example": 31.3
+                                                },
+                                                "externalInteractions": {
+                                                    "properties": {
+                                                        "views": {
+                                                            "type": "integer",
+                                                            "example": 800
+                                                        },
+                                                        "likes": {
+                                                            "type": "integer",
+                                                            "example": 150
+                                                        },
+                                                        "shares": {
+                                                            "type": "integer",
+                                                            "example": 20
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous devez être connecté pour accéder à cette ressource"
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": []
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n'avez pas la permission d'accéder à cette ressource"
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": []
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Utilisateur introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Utilisateur non trouvé"
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": []
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur de serveur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/email/verification-status": {
+            "get": {
+                "tags": [
+                    "Email Verification"
+                ],
+                "summary": "Statut de vérification de l'email",
+                "description": "Retourne le statut de vérification de l'email de l'utilisateur connecté",
+                "operationId": "8684191a544aa439d62a34d4423080bd",
+                "responses": {
+                    "200": {
+                        "description": "Statut récupéré avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "verified": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "email": {
+                                            "type": "string",
+                                            "example": "john.doe@example.com"
+                                        },
+                                        "verified_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "nullable": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de consulter ce statut"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Utilisateur introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Utilisateur non trouvé"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/email/send-verification": {
+            "post": {
+                "tags": [
+                    "Email Verification"
+                ],
+                "summary": "Envoyer email de vérification",
+                "description": "Envoie un email de vérification si l'email n'est pas encore vérifié",
+                "operationId": "5825da9dad6aae7eb3b00342dfbbdbcf",
+                "responses": {
+                    "200": {
+                        "description": "Email de vérification envoyé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Email de vérification envoyé."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Requête invalide ou email déjà vérifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "L'email est déjà vérifié"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès interdit",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission d'envoyer cet email"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Utilisateur introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Utilisateur non trouvé"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Trop de requêtes (rate limit)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Trop de tentatives, veuillez réessayer plus tard"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/email/verify": {
+            "post": {
+                "tags": [
+                    "Email Verification"
+                ],
+                "summary": "Vérifier l'email",
+                "description": "Vérifie l'email à partir des paramètres du lien de vérification",
+                "operationId": "11a3d0bea7a972dbe9605259e008eb20",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "id",
+                                    "hash",
+                                    "expires",
+                                    "signature"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "hash": {
+                                        "type": "string",
+                                        "example": "abc123hash"
+                                    },
+                                    "expires": {
+                                        "type": "integer",
+                                        "example": 1700000000
+                                    },
+                                    "signature": {
+                                        "type": "string",
+                                        "example": "signatureexample"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Email vérifié avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Email vérifié avec succès."
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "user": {
+                                                    "$ref": "#/components/schemas/User"
+                                                },
+                                                "token": {
+                                                    "type": "string",
+                                                    "example": "1|a1b2c3..."
+                                                },
+                                                "token_type": {
+                                                    "type": "string",
+                                                    "example": "Bearer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Lien invalide, expiré ou email déjà vérifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Le lien de vérification est invalide ou a expiré."
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Utilisateur introuvable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Aucun utilisateur trouvé pour l'ID fourni."
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Email déjà vérifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Cet email est déjà vérifié."
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue, veuillez réessayer plus tard."
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/features/search": {
+            "get": {
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Rechercher des fonctionnalités selon des critères",
+                "description": "Filtre les Features par critères",
+                "operationId": "e8a01134d5bdc1911095625badc65026",
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par ID utilisateur",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 2
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Filtrer par nom de feature",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "Campagne"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Résultats filtrés",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FeatureCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de rechercher ces fonctionnalités",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/features/{id}": {
+            "get": {
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Voir une fonctionnalité",
+                "description": "Retourne les détails d'un Feature selon son ID.",
+                "operationId": "41389c397159cab2129d317188cba5b0",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du Feature",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Feature trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FeatureResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Unauthenticated"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Accès interdit"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Feature non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Feature introuvable"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Erreur serveur"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Mettre à jour une fonctionnalité",
+                "description": "Met à jour un Feature existant.",
+                "operationId": "cdaeaa8700e80afb005f68269278ef41",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du Feature",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 8
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Nom modifié"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Feature mis à jour",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FeatureResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de modifier cette fonctionnalité",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Feature non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Aucune fonctionnalité trouvée avec l'ID fourni",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides",
+                                    "errors": {
+                                        "name": [
+                                            "Le champ name est obligatoire ou invalide"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Supprimer une fonctionnalité",
+                "description": "Supprime un Feature par son ID.",
+                "operationId": "bb46523e6ace08d58fbbe3cf118a4f2e",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du Feature",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {},
+                                "example": {
+                                    "message": "Supprimé avec succès."
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Feature non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/features": {
+            "get": {
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Lister toutes les fonctionnalités",
+                "description": "Retourne la liste complète des Features disponibles.",
+                "operationId": "22014dd9cc95707e3e38587872537275",
+                "responses": {
+                    "200": {
+                        "description": "Liste des fonctionnalités récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FeatureCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de lister les fonctionnalités",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Features"
+                ],
+                "summary": "Créer une nouvelle fonctionnalité",
+                "description": "Crée un Feature et le retourne.",
+                "operationId": "4aa3c1825dd1415b6346fde7318d176d",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Nouvelle fonctionnalité"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Feature créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FeatureResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de créer une fonctionnalité",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Les données fournies sont invalides",
+                                    "errors": {
+                                        "name": [
+                                            "Le champ name est obligatoire ou trop long"
+                                        ],
+                                        "other_field": [
+                                            "Valeur invalide pour other_field"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/images/search": {
+            "get": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Lister les images selon des critères",
+                "description": "Retourne une collection d’images filtrées par critères (par défaut limité à l’utilisateur connecté sauf si admin).",
+                "operationId": "800d8e358356cd72cf9eac8a6f39e2bc",
+                "parameters": [
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    },
+                    {
+                        "name": "is_published",
+                        "in": "query",
+                        "description": "Filtrer les images publiées ou non",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "example": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des images filtrées",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImageCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé (droits insuffisants)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de voir ces images",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Aucune image trouvée pour les critères fournis",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Aucune image correspondante trouvée",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue, veuillez réessayer plus tard",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/images/{id}": {
+            "get": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Afficher une image",
+                "description": "Retourne les détails d'une image spécifique par son ID.",
+                "operationId": "69e3d86c2990c0e02e6b18191289fb88",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'image à récupérer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails de l'image",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImageResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous devez être authentifié."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n'avez pas la permission de visualiser cette image."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Image non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Image introuvable avec l'ID fourni."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur lors de la récupération de l'image."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Mettre à jour une image",
+                "description": "Met à jour les informations d'une image spécifique.",
+                "operationId": "62e0e1597ac5c7c5cf899f71b0ee0cbc",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'image à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "example": "/images/updated.jpg"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Image mise à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImageResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous devez être connecté pour effectuer cette action."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n’avez pas la permission de modifier cette image."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Image non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "L'image avec l'ID fourni est introuvable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Les données fournies sont invalides."
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "path": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "Le champ path doit être une URL valide."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur lors de la mise à jour de l'image."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Supprimer une image",
+                "description": "Supprime une image spécifique par son ID.",
+                "operationId": "3218989f90d604b52eafc0896857508d",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'image à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Image supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour supprimer une image",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de supprimer cette image",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Image non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Aucune image trouvée avec l'ID fourni",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Erreur interne du serveur lors de la suppression de l'image",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/images/generate": {
+            "post": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Générer une image",
+                "description": "Génère une image à partir d'un prompt et l'associe à une campagne.",
+                "operationId": "eb30f2fcc857ef2bfe2abce64d397e5b",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "prompt": {
+                                        "type": "string",
+                                        "example": "Une illustration futuriste d'une ville"
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 3
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 12
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Image générée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Image générée avec succès"
+                                        },
+                                        "images": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/ImageResource"
+                                            }
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "image": {
+                                                    "$ref": "#/components/schemas/ImageResource"
+                                                },
+                                                "image_url": {
+                                                    "type": "string",
+                                                    "example": "/images/example.jpg"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour générer une image",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de générer une image pour cette campagne",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Données invalides",
+                                    "errors": {
+                                        "prompt": [
+                                            "Le champ prompt est obligatoire."
+                                        ],
+                                        "campaign_id": [
+                                            "Le champ campaign_id doit être un entier valide."
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Erreur interne du serveur lors de la génération de l'image",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/images": {
+            "get": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Lister les images",
+                "description": "Retourne la liste des images de l'utilisateur (ou toutes pour un admin).",
+                "operationId": "b1db8e9b7397657ba2386f050362885f",
+                "responses": {
+                    "200": {
+                        "description": "Liste des images",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImageCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous devez être authentifié."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n'avez pas la permission de visualiser ces images."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur lors de la récupération des images."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Créer une nouvelle image",
+                "description": "Crée une image pour une campagne.",
+                "operationId": "20ac397f9cc6e51861705795d6e5fec5",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "example": "/images/example.jpg"
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 3
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 12
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Image créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImageResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous devez être connecté pour accéder à cette ressource."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n’avez pas la permission de créer une image pour cette campagne."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Les données fournies sont invalides."
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "path": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "Le champ path est obligatoire."
+                                                    }
+                                                },
+                                                "campaign_id": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "La campagne spécifiée est introuvable."
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur lors de la création de l'image."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/landing-pages/search": {
+            "get": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Lister les landing pages selon des critères",
+                "description": "Retourne la liste des landing pages filtrées selon les critères fournis. Les utilisateurs non-admin ne voient que leurs propres landing pages.",
+                "operationId": "8c78b7aa5e96ab3f4c90cd6c42465ad9",
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par ID utilisateur (uniquement admin)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 3
+                        }
+                    },
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des landing pages",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/LandingPageCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur inattendue",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur lors de la récupération des landing pages."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/landing-pages/{id}": {
+            "get": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Afficher une landing page",
+                "description": "Retourne les détails d'une landing page spécifique.",
+                "operationId": "1ee1a3ca162573a8f1fe4331230fc707",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la landing page",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails de la landing page",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/LandingPageResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Mettre à jour une landing page",
+                "description": "Met à jour le contenu d'une landing page spécifique.",
+                "operationId": "455b773e601f0d0fcb0726465906301c",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la landing page à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "content"
+                                ],
+                                "properties": {
+                                    "content": {
+                                        "type": "object",
+                                        "example": {
+                                            "title": "Nouvelle landing page",
+                                            "sections": {
+                                                "header": "Bienvenue",
+                                                "footer": "Contactez-nous"
+                                            }
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Landing page mise à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Landing page mise à jour avec succès"
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/LandingPageResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous devez être connecté pour accéder à cette ressource."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n’avez pas la permission de modifier cette landing page."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Landing page non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "La landing page demandée est introuvable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Les données fournies sont invalides."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "content": [
+                                                    "Le champ content est obligatoire."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur inattendue est survenue lors de la mise à jour de la landing page."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Supprimer une landing page",
+                "description": "Supprime une landing page spécifique.",
+                "operationId": "313f3c59a07c7aebbda23dcb63e2fcd6",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de la landing page",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Landing page supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Landing page supprimée avec succès"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Landing page non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur lors de la suppression de la landing page"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/landing-pages/generate": {
+            "post": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Générer une landing page",
+                "description": "Génère une landing page à partir d'un prompt pour une campagne spécifique.",
+                "operationId": "5141c9998ed0a03c4f157e516859710b",
+                "requestBody": {
+                    "description": "Données pour générer la landing page",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "prompt": {
+                                        "type": "string",
+                                        "example": "Créer une landing page pour notre nouveau produit X."
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 12
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 7
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Landing page générée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "content": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": [
+                                                            "Titre principal",
+                                                            "Sous-titre",
+                                                            "CTA"
+                                                        ]
+                                                    }
+                                                },
+                                                "campaign_id": {
+                                                    "type": "integer",
+                                                    "example": 12
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "example": "2025-09-25 16:00:00"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Landing page générée avec succès"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "200": {
+                        "description": "Fallback utilisé suite à une erreur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        },
+                                        "fallback": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Landing page générée avec un template de base suite à une erreur"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Validation failed"
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "prompt": [
+                                                    "Le champ prompt est requis"
+                                                ],
+                                                "campaign_id": [
+                                                    "Le champ campaign_id doit être un entier"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur lors de la génération de la landing page"
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Détails de l'exception"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/landing-pages": {
+            "get": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Liste des landing pages",
+                "description": "Retourne la liste des landing pages, filtrable par `campaign_id`.",
+                "operationId": "1005649cc3bae996ec46ff9e2997915b",
+                "parameters": [
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des landing pages",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/LandingPageResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ressource non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "LandingPages"
+                ],
+                "summary": "Créer une landing page",
+                "description": "Crée une nouvelle landing page pour une campagne spécifique.",
+                "operationId": "8ac8710856b988c24c34b84f161c2f5e",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "content": {
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string",
+                                                    "example": "text"
+                                                },
+                                                "value": {
+                                                    "type": "string",
+                                                    "example": "Bienvenue"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 5
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 12
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Landing page créée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/LandingPageResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Validation failed"
+                                        },
+                                        "errors": {
+                                            "properties": {
+                                                "content": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "Le champ content est requis"
+                                                    }
+                                                },
+                                                "campaign_id": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string",
+                                                        "example": "Le champ campaign_id est requis"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/admin/payments": {
+            "get": {
+                "tags": [
+                    "Payments"
+                ],
+                "summary": "Lister tous les paiements",
+                "description": "Retourne la liste de tous les paiements avec les informations utilisateur et transaction.",
+                "operationId": "97a1693187d15c906563e79a6f9a7eda",
+                "responses": {
+                    "200": {
+                        "description": "Liste des paiements",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "id": {
+                                                "type": "integer",
+                                                "example": 12
+                                            },
+                                            "username": {
+                                                "type": "string",
+                                                "example": "John Doe"
+                                            },
+                                            "amount": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "example": 5000
+                                            },
+                                            "currency": {
+                                                "type": "string",
+                                                "example": "Ar"
+                                            },
+                                            "created_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "example": "2025-09-25 15:30:00"
+                                            },
+                                            "expiration_date": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "example": "2025-10-25 15:30:00"
+                                            },
+                                            "transaction_reference": {
+                                                "type": "string",
+                                                "example": "TRX123456789"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à cette ressource."
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission d'accéder à ces paiements."
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ressource non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Aucun paiement trouvé."
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Erreur serveur interne"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/payments": {
+            "post": {
+                "tags": [
+                    "Payments"
+                ],
+                "summary": "Effectuer un paiement",
+                "description": "Crée un paiement pour un utilisateur et active le tarif correspondant.",
+                "operationId": "87709b8d7bebf734964f44c658722416",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amount": {
+                                        "type": "string",
+                                        "example": "5000"
+                                    },
+                                    "currency": {
+                                        "type": "string",
+                                        "example": "Ar"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "example": "Paiement Pro"
+                                    },
+                                    "customer_msisdn": {
+                                        "type": "string",
+                                        "example": "0341234567"
+                                    },
+                                    "merchant_msisdn": {
+                                        "type": "string",
+                                        "example": "0337654321"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Paiement effectué avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "example": 12
+                                        },
+                                        "amount": {
+                                            "type": "number",
+                                            "format": "float",
+                                            "example": 5000
+                                        },
+                                        "currency": {
+                                            "type": "string",
+                                            "example": "Ar"
+                                        },
+                                        "transaction_reference": {
+                                            "type": "string",
+                                            "example": "TRX123456789"
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2025-09-25 15:30:00"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour effectuer un paiement."
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission d'effectuer ce paiement."
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ressource non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Utilisateur ou tarif introuvable."
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur lors du paiement",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Payment error: Montant invalide"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/payments/user": {
+            "get": {
+                "tags": [
+                    "Payments"
+                ],
+                "summary": "Lister les paiements de l'utilisateur connecté",
+                "description": "Retourne la liste des paiements effectués par l'utilisateur connecté.",
+                "operationId": "f0f08336376acc9a234f8503c304f84d",
+                "responses": {
+                    "200": {
+                        "description": "Liste des paiements de l'utilisateur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "amount": {
+                                                "type": "number",
+                                                "format": "float",
+                                                "example": 5000
+                                            },
+                                            "currency": {
+                                                "type": "string",
+                                                "example": "Ar"
+                                            },
+                                            "transaction_reference": {
+                                                "type": "string",
+                                                "example": "TRX123456789"
+                                            },
+                                            "created_at": {
+                                                "type": "string",
+                                                "format": "date-time",
+                                                "example": "2025-09-25 15:30:00"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous devez être connecté pour accéder à vos paiements."
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n'avez pas la permission de consulter ces paiements."
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ressource non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Aucun paiement trouvé pour cet utilisateur."
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Erreur serveur interne"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/password/reset": {
+            "post": {
+                "tags": [
+                    "PasswordReset"
+                ],
+                "summary": "Réinitialiser le mot de passe",
+                "description": "Réinitialise le mot de passe utilisateur avec un token de réinitialisation valide",
+                "operationId": "resetPassword",
+                "requestBody": {
+                    "description": "Données pour réinitialiser le mot de passe",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "token",
+                                    "email",
+                                    "password",
+                                    "password_confirmation"
+                                ],
+                                "properties": {
+                                    "token": {
+                                        "type": "string",
+                                        "example": "token123"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "user@example.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "format": "password",
+                                        "example": "NewPassword123!"
+                                    },
+                                    "password_confirmation": {
+                                        "type": "string",
+                                        "format": "password",
+                                        "example": "NewPassword123!"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Mot de passe réinitialisé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Mot de passe réinitialisé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Données de validation invalides",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Les données fournies sont invalides."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "email": [
+                                                    "L'adresse email est invalide."
+                                                ],
+                                                "password": [
+                                                    "Le mot de passe doit contenir au moins 8 caractères.",
+                                                    "Le mot de passe doit contenir au moins une lettre majuscule.",
+                                                    "Le mot de passe doit contenir au moins un chiffre."
+                                                ],
+                                                "password_confirmation": [
+                                                    "La confirmation du mot de passe ne correspond pas."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur interne",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur interne est survenue. Veuillez réessayer plus tard."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "server": [
+                                                    "Erreur lors de la mise à jour du mot de passe."
+                                                ]
+                                            }
+                                        },
+                                        "debug": {
+                                            "description": "Informations de débogage (uniquement en environnement de développement)",
+                                            "type": "object",
+                                            "example": []
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/password/email": {
+            "post": {
+                "tags": [
+                    "PasswordReset"
+                ],
+                "summary": "Envoyer un lien de réinitialisation du mot de passe",
+                "description": "Envoie un email contenant un lien de réinitialisation de mot de passe à l'adresse spécifiée",
+                "operationId": "sendPasswordResetLink",
+                "requestBody": {
+                    "description": "Adresse email pour envoyer le lien",
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "email"
+                                ],
+                                "properties": {
+                                    "email": {
+                                        "description": "Adresse email de l'utilisateur",
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "user@example.com"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Lien de réinitialisation envoyé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Lien de réinitialisation envoyé par email."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Données de validation invalides",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Les données fournies sont invalides."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "email": [
+                                                    "Le champ email est obligatoire.",
+                                                    "L'adresse email doit être une adresse email valide.",
+                                                    "L'adresse email n'existe pas dans notre système.",
+                                                    "Nous ne pouvons pas envoyer d'email à cette adresse.",
+                                                    "Trop de tentatives. Veuillez réessayer dans 5 minutes."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur interne",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de l'envoi de l'email. Veuillez réessayer."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "server": [
+                                                    "Impossible d'envoyer l'email de réinitialisation.",
+                                                    "Erreur de connexion au service d'email.",
+                                                    "Service d'email temporairement indisponible."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/prompts/search": {
+            "get": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Lister les prompts selon des critères",
+                "description": "Retourne la liste des prompts filtrés selon les critères passés en query. Si l'utilisateur n'est pas admin, il ne verra que ses propres prompts.",
+                "operationId": "searchPrompts",
+                "parameters": [
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    },
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par ID d'utilisateur (admin uniquement)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Recherche textuelle dans le titre et le contenu",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "marketing"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Numéro de page",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "Nombre d'éléments par page",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "example": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des prompts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/PromptResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                },
+                                                "current_page": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "last_page": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "per_page": {
+                                                    "type": "integer",
+                                                    "example": 20
+                                                },
+                                                "from": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "to": {
+                                                    "type": "integer",
+                                                    "example": 10
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Paramètres invalides",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error400"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error401"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error403"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error500"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/prompts/{id}": {
+            "get": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Afficher un prompt",
+                "description": "Retourne les détails d'un prompt spécifique.",
+                "operationId": "7a23a6856e94c5d4fb4a4a79c330ed95",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du prompt",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails du prompt",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PromptResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Prompt non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Mettre à jour un prompt",
+                "description": "Met à jour le contenu d'un prompt spécifique.",
+                "operationId": "37f838e7dbd490382cba9c4f4707a6db",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du prompt",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "content": {
+                                        "type": "string",
+                                        "example": "Nouveau contenu du prompt"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Prompt mis à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PromptResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Prompt non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Supprimer un prompt",
+                "description": "Supprime un prompt spécifique par ID. Seul le propriétaire ou un administrateur peut supprimer un prompt.",
+                "operationId": "deletePrompt",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du prompt à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Prompt supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Prompt supprimé avec succès."
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "example": []
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié - Token manquant ou invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Token d'authentification invalide"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé - Pas le propriétaire du prompt",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n'êtes pas autorisé à supprimer ce prompt"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Prompt non trouvé - ID invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Aucun prompt trouvé avec cet ID"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur serveur lors de la suppression"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/prompts/index": {
+            "get": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Lister tous les prompts",
+                "description": "Retourne la liste de tous les prompts.",
+                "operationId": "2b8486e8248d293967556665d40131eb",
+                "responses": {
+                    "200": {
+                        "description": "Liste des prompts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/PromptResource"
+                                            }
+                                        },
+                                        "total": {
+                                            "type": "integer",
+                                            "example": 15
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Non authentifié"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Vous n’avez pas les permissions nécessaires pour accéder à cette ressource",
+                                    "errors": []
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                },
+                                "example": {
+                                    "success": false,
+                                    "message": "Une erreur interne est survenue lors de la récupération des campagnes"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/prompts/quota/{userId}": {
+            "get": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Obtenir le quota de prompts utilisé par un utilisateur",
+                "description": "Retourne le nombre de prompts utilisés aujourd'hui par un utilisateur donné.",
+                "operationId": "53a0b19d1a342e45b5ab0edef1165ba0",
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Quota de prompts utilisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "user_id": {
+                                                    "type": "integer",
+                                                    "example": 12
+                                                },
+                                                "daily_quota_used": {
+                                                    "type": "integer",
+                                                    "example": 5
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/prompts": {
+            "post": {
+                "tags": [
+                    "Prompts"
+                ],
+                "summary": "Créer un prompt",
+                "description": "Crée un nouveau prompt pour une campagne spécifique.",
+                "operationId": "9080668a27b80154f045d195d4f1bcef",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "content": {
+                                        "type": "string",
+                                        "example": "Créer un prompt pour campagne X"
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 5
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 12
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Prompt créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PromptResource"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Quota dépassé ou tarif manquant",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/socials/search": {
+            "get": {
+                "tags": [
+                    "Socials"
+                ],
+                "summary": "Lister les posts sociaux selon des critères",
+                "description": "Retourne la liste des posts sociaux selon les critères fournis pour l'utilisateur connecté. Les admins voient tous les posts.",
+                "operationId": "7a007528f8f8ecf0237c246c02a8bfb4",
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par ID utilisateur (automatiquement ajouté si non admin)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 12
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des posts sociaux",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SocialResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/socials/{id}": {
+            "get": {
+                "tags": [
+                    "Socials"
+                ],
+                "summary": "Afficher un post social",
+                "description": "Retourne les détails d'un post social spécifique.",
+                "operationId": "adbd7036008d50a4d5a182865df231d8",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post social",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails du post social",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Post social non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Socials"
+                ],
+                "summary": "Mettre à jour un post social",
+                "description": "Met à jour un post social existant.",
+                "operationId": "cdcb69617f13f45a38d87cce27b255ae",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post social",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Nom du post social mis à jour"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Post social mis à jour",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Post social non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Socials"
+                ],
+                "summary": "Supprimer un post social",
+                "description": "Supprime un post social existant.",
+                "operationId": "9f991c53862c609d0a559b7bb76404a1",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post social",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 7
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Post social supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Post social non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/socials": {
+            "get": {
+                "tags": [
+                    "Socials"
+                ],
+                "summary": "Lister tous les posts sociaux",
+                "description": "Retourne tous les posts sociaux.",
+                "operationId": "cd9d4c0f5aac27bfb759d24983c98b71",
+                "responses": {
+                    "200": {
+                        "description": "Liste des posts sociaux",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SocialResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Socials"
+                ],
+                "summary": "Créer un post social",
+                "description": "Crée un nouveau post social.",
+                "operationId": "969ba7a236e8870adf58669eb6403063",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Nom du post social"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Post social créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/social-posts": {
+            "get": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Lister les posts sociaux selon des critères",
+                "description": "Retourne les posts sociaux filtrés selon les critères fournis. Les utilisateurs non-admins ne verront que leurs propres posts.",
+                "operationId": "2757608aeb538ad693d3999b04a43cfa",
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par ID utilisateur (optionnel, seulement pour admins)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    },
+                    {
+                        "name": "campaign_id",
+                        "in": "query",
+                        "description": "Filtrer par ID de campagne (optionnel)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 3
+                        }
+                    },
+                    {
+                        "name": "social_id",
+                        "in": "query",
+                        "description": "Filtrer par ID social (optionnel)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 2
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des posts sociaux filtrés",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SocialPostResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 12
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Non authentifié"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous n'avez pas la permission d'accéder à cette ressource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Ressource non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Aucun post social trouvé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Créer un post social",
+                "description": "Créer un nouveau post social à partir d'un prompt et d'une campagne",
+                "operationId": "61b1e9171d85173dc3262bb3d1087600",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "content": {
+                                        "type": "string",
+                                        "example": "Contenu du post"
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "social_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 3
+                                    },
+                                    "is_published": {
+                                        "type": "boolean",
+                                        "example": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Post créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialPostResource"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation ou contenu invalide",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "example": "no_content"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Accès refusé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/social-posts/{id}": {
+            "get": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Afficher un post social",
+                "description": "Retourne un post social par son ID",
+                "operationId": "97dff84626481df517763d496e559eb6",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post social",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Post social trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialPostResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Non authentifié"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Accès refusé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Post non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Post social non trouvé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Mettre à jour un post social",
+                "description": "Met à jour un post social existant",
+                "operationId": "57402d6bb5fc6fa5d615bde43cfb0c06",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post social à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "content": {
+                                        "type": "string",
+                                        "example": "Contenu mis à jour"
+                                    },
+                                    "is_published": {
+                                        "type": "boolean",
+                                        "example": false
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Post mis à jour",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SocialPostResource"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Accès refusé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Post non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Post social non trouvé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Supprimer un post social",
+                "description": "Supprime un post social par ID",
+                "operationId": "0fa49b416cc5c1bec242f0f91d8955d7",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post social à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Post supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Accès refusé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Post non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Post social non trouvé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/social-posts/index": {
+            "get": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Lister tous les posts sociaux",
+                "description": "Retourne tous les posts sociaux. Les autorisations sont respectées selon le rôle de l'utilisateur.",
+                "operationId": "9b6992af489ab3f8d3d25e2b6d01bf21",
+                "responses": {
+                    "200": {
+                        "description": "Liste des posts sociaux",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SocialPostResource"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer",
+                                                    "example": 12
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Non authentifié"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Accès refusé"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur interne du serveur"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/social-posts/{id}/regenerate": {
+            "post": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Régénérer un post social",
+                "description": "Régénère le contenu d'un post social existant",
+                "operationId": "273c68e92ae5210abc5d6ceb1a2c58a5",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du post à régénérer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "content": {
+                                        "type": "string",
+                                        "example": "Nouveau contenu régénéré"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Post régénéré avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Post régénéré avec succès"
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Aucun contenu généré",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "example": "no_content"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne de régénération",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur lors de la régénération"
+                                        },
+                                        "type": {
+                                            "type": "string",
+                                            "example": "regeneration_error"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/social-posts/generate": {
+            "post": {
+                "tags": [
+                    "SocialPosts"
+                ],
+                "summary": "Générer des posts pour plusieurs plateformes",
+                "description": "Génère et crée des posts sur plusieurs plateformes à partir d'un topic, campagne et prompt",
+                "operationId": "9038dc778b77bdf83e177594f7edcf86",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "topic": {
+                                        "type": "string",
+                                        "example": "Nouvelle campagne"
+                                    },
+                                    "platforms": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "enum": [
+                                                "linkedin",
+                                                "x",
+                                                "tiktok"
+                                            ]
+                                        }
+                                    },
+                                    "campaign_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "prompt_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "tone": {
+                                        "type": "string",
+                                        "example": "friendly"
+                                    },
+                                    "language": {
+                                        "type": "string",
+                                        "example": "french"
+                                    },
+                                    "hashtags": {
+                                        "type": "string",
+                                        "example": "#marketing"
+                                    },
+                                    "target_audience": {
+                                        "type": "string",
+                                        "example": "professionnels du marketing"
+                                    },
+                                    "is_published": {
+                                        "type": "boolean",
+                                        "example": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Posts générés avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "generated": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "posts": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/SocialPostResource"
+                                            }
+                                        },
+                                        "count": {
+                                            "type": "integer",
+                                            "example": 3
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Erreur de validation"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur lors de la génération",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Failed to generate posts"
+                                        },
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Exception message"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/suggestions/{userId}": {
+            "get": {
+                "tags": [
+                    "Suggestions"
+                ],
+                "summary": "Récupérer les suggestions pour un utilisateur",
+                "description": "Renvoie la liste des suggestions pour l'utilisateur authentifié",
+                "operationId": "2e6f05e8e19a11ebc3773cd7d204845a",
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Suggestions récupérées avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "suggestions": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "integer",
+                                                        "example": 1
+                                                    },
+                                                    "title": {
+                                                        "type": "string",
+                                                        "example": "Titre de la suggestion"
+                                                    },
+                                                    "description": {
+                                                        "type": "string",
+                                                        "example": "Description détaillée"
+                                                    },
+                                                    "created_at": {
+                                                        "type": "string",
+                                                        "format": "date-time",
+                                                        "example": "2025-09-25 10:00:00"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur lors de la récupération des suggestions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la récupération des suggestions."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarifs/search": {
+            "get": {
+                "tags": [
+                    "Tarifs"
+                ],
+                "summary": "Lister les tarifs selon des critères",
+                "description": "Retourne une liste de tarifs filtrés selon les critères passés en query parameters.",
+                "operationId": "1e3f036bcea82342683c82ab5b350f34",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Filtrer par nom du tarif",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "amount",
+                        "in": "query",
+                        "description": "Filtrer par montant",
+                        "required": false,
+                        "schema": {
+                            "type": "number",
+                            "format": "float"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des tarifs récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/TarifResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarifs/{id}": {
+            "get": {
+                "tags": [
+                    "Tarifs"
+                ],
+                "summary": "Afficher un tarif",
+                "description": "Récupère les informations d’un tarif spécifique par ID",
+                "operationId": "ece726a5b51d4dd5a09dd262bdcdfdda",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du tarif",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails du tarif",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Tarif non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Tarif introuvable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Tarifs"
+                ],
+                "summary": "Mettre à jour un tarif",
+                "description": "Met à jour les informations d’un tarif existant",
+                "operationId": "8f27f369337d937ffa022efa39fae0d6",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du tarif à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "amount",
+                                    "max_limit"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Tarif Standard"
+                                    },
+                                    "amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 29.99
+                                    },
+                                    "max_limit": {
+                                        "type": "integer",
+                                        "example": 50
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Tarif mis à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Tarif non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Tarif introuvable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "The given data was invalid."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "amount": [
+                                                    "Le champ amount doit être un nombre."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Tarifs"
+                ],
+                "summary": "Supprimer un tarif",
+                "description": "Supprime un tarif existant par son identifiant",
+                "operationId": "980701f7033035e8328af7dcb8efc567",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du tarif à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Tarif supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Tarif non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Tarif introuvable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarifs": {
+            "get": {
+                "tags": [
+                    "Tarifs"
+                ],
+                "summary": "Lister tous les tarifs",
+                "description": "Récupère la liste complète des tarifs disponibles",
+                "operationId": "4586fdd2682253d9b7d71bb73ea5ff37",
+                "responses": {
+                    "200": {
+                        "description": "Liste des tarifs",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/TarifResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Tarifs"
+                ],
+                "summary": "Créer un tarif",
+                "description": "Crée un nouveau tarif avec les données fournies",
+                "operationId": "0efd316450ea82501b29eda5cfac27db",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "amount",
+                                    "max_limit"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Tarif Premium"
+                                    },
+                                    "amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 49.99
+                                    },
+                                    "max_limit": {
+                                        "type": "integer",
+                                        "example": 100
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Tarif créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "The given data was invalid."
+                                        },
+                                        "errors": {
+                                            "type": "object",
+                                            "example": {
+                                                "name": [
+                                                    "Le champ name est obligatoire."
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarif-features/{id}": {
+            "get": {
+                "tags": [
+                    "Tarif Features"
+                ],
+                "summary": "Récupérer un TarifFeature par ID",
+                "description": "Retourne les détails d'une caractéristique de tarif spécifique.",
+                "operationId": "82ecf452d2dfc0c38cf288ec2c22b03e",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TarifFeature",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Détails du TarifFeature",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifFeatureResource"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TarifFeature non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "TarifFeature not found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Tarif Features"
+                ],
+                "summary": "Mettre à jour une caractéristique de tarif",
+                "description": "Met à jour le nom ou le tarif associé d'une feature existante.",
+                "operationId": "b6f6ab503010633d4a5038732b07724f",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TarifFeature",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Support Premium 24/7"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "TarifFeature mis à jour",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifFeatureResource"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TarifFeature non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "TarifFeature not found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Tarif Features"
+                ],
+                "summary": "Supprimer une caractéristique de tarif",
+                "description": "Supprime une feature existante par son ID.",
+                "operationId": "b037634a6273f04e6ffa2f1839618801",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TarifFeature à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Feature supprimée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Feature non trouvée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "TarifFeature not found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarif-features": {
+            "get": {
+                "tags": [
+                    "Tarif Features"
+                ],
+                "summary": "Récupérer tous les TarifFeatures",
+                "description": "Retourne la liste complète des caractéristiques de tarifs.",
+                "operationId": "75470fc7b052d939bb1c31d7fd4bf611",
+                "responses": {
+                    "200": {
+                        "description": "Liste complète des TarifFeatures",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifFeatureCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Tarif Features"
+                ],
+                "summary": "Créer une nouvelle caractéristique de tarif",
+                "description": "Crée un TarifFeature pour un tarif donné.",
+                "operationId": "eec3b58a83a41cacb95e487e683012b6",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "tarif_id",
+                                    "name"
+                                ],
+                                "properties": {
+                                    "tarif_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Support 24/7"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "TarifFeature créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifFeatureResource"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Données invalides",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Validation failed"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarif-users/search": {
+            "get": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Récupérer les TarifUsers selon des critères",
+                "description": "Retourne une collection de TarifUser filtrée selon les critères fournis. Si l'utilisateur n'est pas admin, seuls ses propres enregistrements sont renvoyés.",
+                "operationId": "8cc4cd9f346b0323fe91edd88202c3dd",
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par user_id (optionnel, non admin ignoré)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "tarif_id",
+                        "in": "query",
+                        "description": "Filtrer par tarif_id (optionnel)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 2
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Collection de TarifUser renvoyée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifUserCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la récupération des données"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarif-users/{id}": {
+            "get": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Afficher un TarifUser",
+                "description": "Retourne les détails d'un TarifUser par ID",
+                "operationId": "da4e9c848e97ba49f577187d31df795d",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TarifUser",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "TarifUser renvoyé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifUserResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TarifUser non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Mettre à jour un TarifUser",
+                "description": "Met à jour les informations d'un TarifUser existant",
+                "operationId": "abeb9c036d85b4e4bb0e2ecbd488026d",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TarifUser à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "tarif_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "expired_at": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "example": "2025-11-25 12:00"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "TarifUser mis à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifUserResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TarifUser non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Le tarif_id est requis"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la mise à jour"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Supprimer un TarifUser",
+                "description": "Supprime un TarifUser par ID",
+                "operationId": "3da9065f9f88da2326119292144684af",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TarifUser à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "TarifUser supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TarifUser non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la suppression"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarif-users": {
+            "get": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Récupérer les TarifUsers selon des critères",
+                "description": "Retourne une collection de TarifUser filtrée selon les critères fournis. Si l'utilisateur n'est pas admin, seuls ses propres enregistrements sont renvoyés.",
+                "operationId": "66e34f8edf0679e484748e7ea951091e",
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "in": "query",
+                        "description": "Filtrer par user_id (optionnel, non admin ignoré)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "tarif_id",
+                        "in": "query",
+                        "description": "Filtrer par tarif_id (optionnel)",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 2
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Collection de TarifUser renvoyée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifUserCollection"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la récupération des données"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Créer un nouveau TarifUser",
+                "description": "Crée un TarifUser pour un utilisateur",
+                "operationId": "ff98bd9615b3e44c39c18f820beb0c18",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "tarif_id",
+                                    "user_id"
+                                ],
+                                "properties": {
+                                    "tarif_id": {
+                                        "type": "integer",
+                                        "example": 2
+                                    },
+                                    "user_id": {
+                                        "type": "integer",
+                                        "example": 5
+                                    },
+                                    "expired_at": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "example": "2025-10-25 12:00"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "TarifUser créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TarifUserResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Erreur de validation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Le tarif_id est requis"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la création"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/tarif-users/latest/{userId}": {
+            "get": {
+                "tags": [
+                    "TarifUsers"
+                ],
+                "summary": "Récupérer le dernier TarifUser pour un utilisateur",
+                "description": "Retourne le dernier TarifUser actif pour l'utilisateur spécifié. Si aucun tarif n'est trouvé, renvoie null.",
+                "operationId": "2507531ba3b17911a2243a25a2a6e49b",
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Dernier TarifUser récupéré avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/TarifUserResource"
+                                        },
+                                        {
+                                            "properties": {
+                                                "success": {
+                                                    "type": "boolean",
+                                                    "example": true
+                                                },
+                                                "data": {
+                                                    "type": "null",
+                                                    "example": null
+                                                },
+                                                "message": {
+                                                    "type": "string",
+                                                    "example": "Aucun tarif trouvé pour cet utilisateur."
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Utilisateur non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la récupération du dernier tarif"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/type-campaigns/search": {
+            "get": {
+                "tags": [
+                    "TypeCampaigns"
+                ],
+                "summary": "Récupère les TypeCampaign selon des critères",
+                "description": "Retourne une liste de TypeCampaign filtrée selon les critères passés en query. Si l'utilisateur n'est pas admin, filtrage automatique par user_id.",
+                "operationId": "9f86e07f74b8fab16e46a5bb3b510716",
+                "parameters": [
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "Filtre par nom du type de campagne",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "Marketing"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des TypeCampaign récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/TypeCampaignResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la récupération des TypeCampaign"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/type-campaigns/{id}": {
+            "get": {
+                "tags": [
+                    "TypeCampaigns"
+                ],
+                "summary": "Afficher un TypeCampaign",
+                "description": "Récupère un TypeCampaign par son ID.",
+                "operationId": "0528947cd25210f43d23183cd249bd08",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TypeCampaign",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "TypeCampaign trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TypeCampaignResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TypeCampaign non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "TypeCampaigns"
+                ],
+                "summary": "Mettre à jour un TypeCampaign",
+                "description": "Met à jour un TypeCampaign existant.",
+                "operationId": "4c80365b14dbd95361f9332854c78489",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TypeCampaign à mettre à jour",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Nouvelle campagne marketing"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "TypeCampaign mis à jour",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TypeCampaignResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TypeCampaign non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Données invalides",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Le nom est requis"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "TypeCampaigns"
+                ],
+                "summary": "Supprime un TypeCampaign",
+                "description": "Supprime un TypeCampaign existant par son ID. Nécessite les droits de suppression.",
+                "operationId": "1e9fda4143b6a998196a760881e16ebc",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID du TypeCampaign à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "TypeCampaign supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "TypeCampaign non trouvé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Not Found"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la suppression du TypeCampaign"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/type-campaigns": {
+            "get": {
+                "tags": [
+                    "TypeCampaigns"
+                ],
+                "summary": "Liste tous les TypeCampaign",
+                "description": "Récupère tous les TypeCampaign pour les utilisateurs autorisés.",
+                "operationId": "a83015b7330b4f0745c73526fdcb20e1",
+                "responses": {
+                    "200": {
+                        "description": "Liste des TypeCampaign",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/TypeCampaignResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "TypeCampaigns"
+                ],
+                "summary": "Créer un TypeCampaign",
+                "description": "Crée un nouveau TypeCampaign.",
+                "operationId": "b6f2726a1fe0d1d8ae53e37d283eebb1",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Campagne marketing"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "TypeCampaign créé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TypeCampaignResource"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès refusé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Données invalides",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Le nom est requis"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/user/change-password": {
+            "post": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Changer le mot de passe d'un utilisateur authentifié",
+                "description": "Permet à l'utilisateur connecté de changer son mot de passe en fournissant l'ancien et le nouveau mot de passe.",
+                "operationId": "90caeaca9052218c3b4f1eed102e1da8",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "currentPassword",
+                                    "newPassword",
+                                    "newPassword_confirmation"
+                                ],
+                                "properties": {
+                                    "currentPassword": {
+                                        "type": "string",
+                                        "example": "ancienMotDePasse123"
+                                    },
+                                    "newPassword": {
+                                        "type": "string",
+                                        "example": "nouveauMotDePasse123"
+                                    },
+                                    "newPassword_confirmation": {
+                                        "type": "string",
+                                        "example": "nouveauMotDePasse123"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Mot de passe modifié avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Mot de passe modifié avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Erreur lors du changement de mot de passe",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Mot de passe actuel incorrect."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Données invalides ou confirmation du mot de passe échouée",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Le champ newPassword doit être confirmé."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/user/{id}": {
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Supprimer un utilisateur",
+                "description": "Supprime un utilisateur spécifié par son ID. L'utilisateur authentifié ne peut pas se supprimer lui-même.",
+                "operationId": "08d4c8edcd7de080c6128a966dcce4c1",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'utilisateur à supprimer",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 5
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Utilisateur supprimé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Utilisateur supprimé avec succès."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Tentative de suppression de son propre compte",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vous ne pouvez pas supprimer votre propre compte."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Utilisateur non authentifié",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthorized"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Utilisateur non autorisé à effectuer cette action",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Forbidden"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue lors de la suppression de l'utilisateur."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/users": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Lister les utilisateurs",
+                "description": "Récupère une liste paginée des utilisateurs. Possibilité de filtrer par rôle et vérification email, et de trier par colonnes.",
+                "operationId": "c208f5a9f57878cd2aa19b1a470f91cf",
+                "parameters": [
+                    {
+                        "name": "role",
+                        "in": "query",
+                        "description": "Filtrer par rôle",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "admin"
+                        }
+                    },
+                    {
+                        "name": "verified",
+                        "in": "query",
+                        "description": "Filtrer par utilisateurs vérifiés (true/false)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "example": true
+                        }
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "description": "Colonne de tri",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "created_at"
+                        }
+                    },
+                    {
+                        "name": "sort_order",
+                        "in": "query",
+                        "description": "Ordre de tri",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ],
+                            "example": "desc"
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "Nombre d'utilisateurs par page",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "example": 15
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Liste des utilisateurs récupérée avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/UserResource"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Accès non autorisé",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Accès non autorisé."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Erreur serveur",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Une erreur est survenue."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Créer un utilisateur",
+                "description": "Crée un nouvel utilisateur",
+                "operationId": "UserStore",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "John Doe"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "example": "john@example.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "example": "secret123"
+                                    },
+                                    "role": {
+                                        "type": "string",
+                                        "enum": [
+                                            "user",
+                                            "admin"
+                                        ],
+                                        "example": "user"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Utilisateur créé avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Utilisateur créé avec succès."
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Données invalides ou erreur"
+                    },
+                    "401": {
+                        "description": "Non authentifié"
+                    },
+                    "403": {
+                        "description": "Accès non autorisé"
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur"
+                    }
+                }
+            }
+        },
+        "/api/users/{id}": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Afficher un utilisateur",
+                "description": "Récupère les informations d'un utilisateur spécifique",
+                "operationId": "UserShow",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Non authentifié"
+                    },
+                    "403": {
+                        "description": "Accès non autorisé"
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur"
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Mettre à jour un utilisateur",
+                "description": "Met à jour les informations d'un utilisateur existant",
+                "operationId": "UserUpdate",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID de l'utilisateur",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "John Doe"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "example": "john@example.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "example": "secret123"
+                                    },
+                                    "role": {
+                                        "type": "string",
+                                        "enum": [
+                                            "user",
+                                            "admin"
+                                        ],
+                                        "example": "user"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Utilisateur mis à jour avec succès",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Utilisateur mis à jour avec succès."
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/UserResource"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Données invalides"
+                    },
+                    "401": {
+                        "description": "Non authentifié"
+                    },
+                    "403": {
+                        "description": "Accès non autorisé"
+                    },
+                    "500": {
+                        "description": "Erreur interne du serveur"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CampaignResource": {
+                "title": "Campaign Resource",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Campagne de test"
+                    },
+                    "user_id": {
+                        "type": "integer",
+                        "example": 10
+                    },
+                    "type_campaign_id": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "status": {
+                        "properties": {
+                            "value": {
+                                "type": "string",
+                                "example": "active"
+                            },
+                            "label": {
+                                "type": "string",
+                                "example": "Active"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "is_published": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Description de la campagne"
+                    },
+                    "user": {
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "example": 10
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Jean Dupont"
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "user_has_liked": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "user_has_shared": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "type": {
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "example": 2
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Campagne Marketing"
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "dates": {
+                        "properties": {
+                            "created_at": {
+                                "type": "string",
+                                "example": "2025-09-21 12:00"
+                            },
+                            "updated_at": {
+                                "type": "string",
+                                "example": "2025-09-21 12:30"
+                            },
+                            "time_ago": {
+                                "type": "string",
+                                "example": "il y a 2 heures"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "images_count": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "landing_pages_count": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "social_posts_count": {
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "total_views": {
+                        "type": "integer",
+                        "example": 1000
+                    },
+                    "total_likes": {
+                        "type": "integer",
+                        "example": 50
+                    },
+                    "total_shares": {
+                        "type": "integer",
+                        "example": 20
+                    },
+                    "images": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "id": {
+                                    "type": "integer",
+                                    "example": 1
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "example": "https://cdn.site.com/image1.jpg"
+                                },
+                                "alt": {
+                                    "type": "string",
+                                    "example": "Image de la campagne"
+                                },
+                                "is_published": {
+                                    "type": "boolean",
+                                    "example": true
+                                },
+                                "created_at": {
+                                    "type": "string",
+                                    "example": "2025-09-21 12:15"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "PopularCampaignResourceSchema": {
+                "title": "Popular Campaign Resource",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Campagne populaire"
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Description de la campagne"
+                    },
+                    "type_campaign_id": {
+                        "type": "integer",
+                        "example": 2
+                    },
+                    "image_path": {
+                        "type": "string",
+                        "example": "https://cdn.site.com/image1.jpg"
+                    },
+                    "total_views": {
+                        "type": "integer",
+                        "example": 1200
+                    },
+                    "total_likes": {
+                        "type": "integer",
+                        "example": 150
+                    }
+                },
+                "type": "object"
+            },
+            "CampaignFeaturesResource": {
+                "title": "Campaign Features Resource",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "campaign_id": {
+                        "type": "integer",
+                        "example": 10
+                    },
+                    "feature_id": {
+                        "type": "integer",
+                        "example": 3
+                    }
+                },
+                "type": "object"
+            },
+            "CampaignInteractionResource": {
+                "title": "Campaign Interaction",
+                "description": "Représentation d'une interaction utilisateur avec une campagne",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 101
+                    },
+                    "campaign_id": {
+                        "description": "Identifiant de la campagne",
+                        "type": "integer",
+                        "example": 12
+                    },
+                    "user_id": {
+                        "description": "Identifiant de l’utilisateur ayant interagi",
+                        "type": "integer",
+                        "example": 45
+                    },
+                    "type": {
+                        "description": "Type d’interaction (view, like, share…)",
+                        "type": "string",
+                        "example": "like"
+                    },
+                    "views": {
+                        "description": "Nombre de vues associées",
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "likes": {
+                        "description": "Nombre de likes associés",
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "shares": {
+                        "description": "Nombre de partages associés",
+                        "type": "integer",
+                        "example": 0
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25T12:34:56Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25T14:12:00Z"
+                    }
+                },
+                "type": "object"
+            },
+            "CampaignInteractionMeta": {
+                "title": "Campaign Interaction Meta",
+                "description": "Métadonnées globales sur les interactions d'une campagne",
+                "properties": {
+                    "total_interactions": {
+                        "description": "Nombre total d’interactions",
+                        "type": "integer",
+                        "example": 50
+                    },
+                    "total_views": {
+                        "description": "Nombre total de vues",
+                        "type": "integer",
+                        "example": 120
+                    },
+                    "total_likes": {
+                        "description": "Nombre total de likes",
+                        "type": "integer",
+                        "example": 30
+                    },
+                    "total_shares": {
+                        "description": "Nombre total de partages",
+                        "type": "integer",
+                        "example": 10
+                    }
+                },
+                "type": "object"
+            },
+            "CampaignTemplateResource": {
+                "title": "Campaign Template",
+                "description": "Représentation d'un modèle de campagne avec ses stats et informations détaillées",
+                "properties": {
+                    "id": {
+                        "description": "Identifiant du template",
+                        "type": "integer",
+                        "example": 7
+                    },
+                    "name": {
+                        "description": "Nom du template",
+                        "type": "string",
+                        "example": "Template Marketing Automatique"
+                    },
+                    "description": {
+                        "description": "Description du template",
+                        "type": "string",
+                        "example": "Template pour campagne marketing automatisée"
+                    },
+                    "category": {
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "example": 2
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Marketing"
+                            },
+                            "icon": {
+                                "type": "string",
+                                "example": "marketing-icon"
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "type": {
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "example": 1
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Email Campaign"
+                            }
+                        },
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "author": {
+                        "description": "Auteur du template",
+                        "type": "string",
+                        "example": "John Doe"
+                    },
+                    "thumbnail": {
+                        "description": "URL de la miniature du template",
+                        "type": "string",
+                        "example": "https://example.com/thumbnails/template7.png"
+                    },
+                    "preview": {
+                        "description": "URL de l'aperçu du template",
+                        "type": "string",
+                        "example": "https://example.com/previews/template7.png"
+                    },
+                    "isPremium": {
+                        "description": "Indique si le template est premium",
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "rating": {
+                        "description": "Note moyenne du template",
+                        "type": "number",
+                        "format": "float",
+                        "example": 4.5
+                    },
+                    "uses": {
+                        "description": "Nombre de fois que le template a été utilisé",
+                        "type": "integer",
+                        "example": 120
+                    },
+                    "tags": {
+                        "description": "Tags associés au template",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "example": [
+                            "marketing",
+                            "automation",
+                            "email"
+                        ]
+                    },
+                    "socialPosts": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "id": {
+                                    "type": "integer",
+                                    "example": 101
+                                },
+                                "content": {
+                                    "type": "string",
+                                    "example": "Découvrez notre nouveau produit !"
+                                },
+                                "created_at": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "example": "2025-09-25 12:34"
+                                },
+                                "social": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "integer",
+                                            "example": 3
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "example": "LinkedIn"
+                                        }
+                                    },
+                                    "type": "object",
+                                    "nullable": true
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "createdAt": {
+                        "description": "Date de création du template",
+                        "type": "string",
+                        "format": "date",
+                        "example": "2025-09-01"
+                    }
+                },
+                "type": "object"
+            },
+            "Error400": {
+                "title": "Requête incorrecte",
+                "description": "Les paramètres de la requête sont invalides",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Paramètres de requête invalides"
+                    }
+                },
+                "type": "object"
+            },
+            "Error401": {
+                "title": "Non authentifié",
+                "description": "Authentification requise ou token invalide",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Authentification requise"
+                    }
+                },
+                "type": "object"
+            },
+            "Error403": {
+                "title": "Accès refusé",
+                "description": "Permissions insuffisantes",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Accès non autorisé"
+                    }
+                },
+                "type": "object"
+            },
+            "Error422": {
+                "title": "Erreur de validation",
+                "description": "Données de validation invalides",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Les données fournies sont invalides"
+                    },
+                    "errors": {
+                        "type": "object",
+                        "example": {
+                            "email": [
+                                "Le champ email est obligatoire."
+                            ],
+                            "password": [
+                                "Le mot de passe doit contenir au moins 8 caractères."
+                            ]
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "Error500": {
+                "title": "Erreur serveur",
+                "description": "Erreur interne du serveur",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Erreur interne du serveur"
+                    }
+                },
+                "type": "object"
+            },
+            "ErrorResponse": {
+                "title": "Erreur générique",
+                "description": "Structure de réponse en cas d'erreur",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "Une erreur est survenue"
+                    },
+                    "errors": {
+                        "description": "Détails des erreurs de validation (optionnel)",
+                        "type": "object",
+                        "example": {
+                            "email": [
+                                "Le champ email est obligatoire."
+                            ]
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "FeatureResource": {
+                "title": "Feature Resource",
+                "description": "Représentation d'une fonctionnalité (Feature)",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 12
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Nouvelle Fonctionnalité"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 15:30"
+                    }
+                },
+                "type": "object"
+            },
+            "FeatureCollection": {
+                "title": "Feature Collection",
+                "description": "Collection de fonctionnalités",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FeatureResource"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "ImageResource": {
+                "title": "Image Resource",
+                "description": "Représentation d'une image",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 101
+                    },
+                    "path": {
+                        "type": "string",
+                        "example": "/uploads/images/example.png"
+                    },
+                    "is_published": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "campaign_id": {
+                        "type": "integer",
+                        "example": 5,
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25T15:30:00Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25T15:45:00Z"
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "example": "Image générée à partir d'une IA",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "ImageCollection": {
+                "title": "Image Collection",
+                "description": "Collection d'images avec métadonnées",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ImageResource"
+                        }
+                    },
+                    "meta": {
+                        "properties": {
+                            "total": {
+                                "type": "integer",
+                                "example": 10
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "LandingPageResource": {
+                "title": "Landing Page Resource",
+                "description": "Représentation d'une landing page",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 7
+                    },
+                    "content": {
+                        "type": "string",
+                        "example": "<h1>Bienvenue</h1>"
+                    },
+                    "campaign_id": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "is_published": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 15:30:00"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 16:00:00"
+                    }
+                },
+                "type": "object"
+            },
+            "LandingPageCollection": {
+                "title": "Landing Page Collection",
+                "description": "Collection de landing pages",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/LandingPageResource"
+                        }
+                    },
+                    "meta": {
+                        "properties": {
+                            "total": {
+                                "type": "integer",
+                                "example": 12
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "PromptResource": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "content": {
+                        "type": "string",
+                        "example": "Créer un prompt pour campagne X"
+                    },
+                    "campaign_id": {
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 15:30:00"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 15:30:00"
+                    }
+                },
+                "type": "object"
+            },
+            "SocialResource": {
+                "title": "Social Resource",
+                "description": "Représente un post social",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "example": "Nom du post social"
+                    }
+                },
+                "type": "object"
+            },
+            "SocialPostResource": {
+                "title": "SocialPost Resource",
+                "description": "Représente un post social",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "content": {
+                        "type": "string",
+                        "example": "Contenu du post social"
+                    },
+                    "is_published": {
+                        "type": "boolean",
+                        "example": true
+                    },
+                    "social_id": {
+                        "type": "integer",
+                        "example": 2
+                    },
+                    "campaign_id": {
+                        "type": "integer",
+                        "example": 3
+                    },
+                    "prompt_id": {
+                        "type": "integer",
+                        "example": 4
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 12:34:56"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 12:34:56"
+                    },
+                    "social": {
+                        "description": "Relation chargée du social",
+                        "type": "object",
+                        "example": {
+                            "id": 2,
+                            "name": "Nom du social"
+                        },
+                        "nullable": true
+                    },
+                    "campaign": {
+                        "description": "Relation chargée de la campagne",
+                        "type": "object",
+                        "example": {
+                            "id": 3,
+                            "title": "Nom de la campagne"
+                        },
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "TarifResource": {
+                "description": "Représente un tarif",
+                "properties": {
+                    "id": {
+                        "description": "ID du tarif",
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "description": "Nom du tarif",
+                        "type": "string",
+                        "example": "Pro"
+                    },
+                    "amount": {
+                        "description": "Montant du tarif",
+                        "type": "number",
+                        "format": "float",
+                        "example": 29.99
+                    },
+                    "max_limit": {
+                        "description": "Limite maximale associée au tarif",
+                        "type": "integer",
+                        "example": 50
+                    }
+                },
+                "type": "object"
+            },
+            "TarifFeatureResource": {
+                "title": "Tarif Feature",
+                "description": "Représentation d'une fonctionnalité liée à un tarif",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "tarif_id": {
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Support Premium"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 12:30"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 12:30"
+                    }
+                },
+                "type": "object"
+            },
+            "TarifFeatureCollection": {
+                "title": "Tarif Feature Collection",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TarifFeatureResource"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "TarifUserCollection": {
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TarifUserResource"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "TarifUserResource": {
+                "title": "TarifUser",
+                "description": "Représentation d'un TarifUser",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "tarif_id": {
+                        "type": "integer",
+                        "example": 2
+                    },
+                    "user_id": {
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 12:00"
+                    },
+                    "expired_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-10-25 12:00"
+                    },
+                    "tarif": {
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "example": 2
+                            },
+                            "name": {
+                                "type": "string",
+                                "example": "Premium"
+                            },
+                            "amount": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 99.99
+                            },
+                            "max_limit": {
+                                "type": "integer",
+                                "example": 100
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "TypeCampaignResource": {
+                "title": "TypeCampaignResource",
+                "description": "Représentation d'un TypeCampaign",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Marketing"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 14:30"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25 14:30"
+                    }
+                },
+                "type": "object"
+            },
+            "User": {
+                "title": "User",
+                "description": "Représentation d'un utilisateur",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "John Doe"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "example": "john.doe@example.com"
+                    },
+                    "role": {
+                        "type": "string",
+                        "example": "user"
+                    },
+                    "email_verified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "UserResource": {
+                "title": "User Resource",
+                "description": "Représentation d'un utilisateur",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "John Doe"
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "john@example.com"
+                    },
+                    "role": {
+                        "type": "string",
+                        "example": "admin"
+                    },
+                    "email_verified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-25T19:00:00Z"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-01T12:00:00Z"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-09-20T10:00:00Z"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "securitySchemes": {
+            "sanctum": {
+                "type": "apiKey",
+                "description": "Enter token in format (Bearer <token>)",
+                "name": "Authorization",
+                "in": "header"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Authentication",
+            "description": "Authentication"
+        },
+        {
+            "name": "Campaigns",
+            "description": "Campaigns"
+        },
+        {
+            "name": "CampaignFeatures",
+            "description": "CampaignFeatures"
+        },
+        {
+            "name": "Campaign Interactions",
+            "description": "Campaign Interactions"
+        },
+        {
+            "name": "Campaign Templates",
+            "description": "Campaign Templates"
+        },
+        {
+            "name": "Dashboard",
+            "description": "Dashboard"
+        },
+        {
+            "name": "Email Verification",
+            "description": "Email Verification"
+        },
+        {
+            "name": "Features",
+            "description": "Features"
+        },
+        {
+            "name": "Images",
+            "description": "Images"
+        },
+        {
+            "name": "LandingPages",
+            "description": "LandingPages"
+        },
+        {
+            "name": "Payments",
+            "description": "Payments"
+        },
+        {
+            "name": "PasswordReset",
+            "description": "PasswordReset"
+        },
+        {
+            "name": "Prompts",
+            "description": "Prompts"
+        },
+        {
+            "name": "Socials",
+            "description": "Socials"
+        },
+        {
+            "name": "SocialPosts",
+            "description": "SocialPosts"
+        },
+        {
+            "name": "Suggestions",
+            "description": "Suggestions"
+        },
+        {
+            "name": "Tarifs",
+            "description": "Tarifs"
+        },
+        {
+            "name": "Tarif Features",
+            "description": "Tarif Features"
+        },
+        {
+            "name": "TarifUsers",
+            "description": "TarifUsers"
+        },
+        {
+            "name": "TypeCampaigns",
+            "description": "TypeCampaigns"
+        },
+        {
+            "name": "User",
+            "description": "User"
+        },
+        {
+            "name": "Users",
+            "description": "Users"
+        }
+    ],
+    "security": [
+        {
+            "sanctum": []
+        }
+    ]
+}

--- a/docs/api-docs.yaml
+++ b/docs/api-docs.yaml
@@ -1,0 +1,8458 @@
+openapi: 3.0.0
+info:
+  title: 'PostNova.AI – API SaaS de génération de contenus marketing'
+  description: 'Spécification OpenAPI de la plateforme PostNova.AI pour créer automatiquement des contenus marketing (LinkedIn, TikTok, X).'
+  contact:
+    name: 'Support Equipe2 PostNova.AI'
+    email: hei.lisa.30@gmail.com
+  version: 1.0.0
+servers:
+  -
+    url: 'http://localhost:8000'
+    description: 'Serveur principal'
+paths:
+  /api/auth/login:
+    post:
+      tags:
+        - Authentication
+      summary: 'Connexion utilisateur'
+      description: 'Authentifie un utilisateur et retourne un token JWT'
+      operationId: 02395a73cadbcda572185a01c3cd2f4f
+      requestBody:
+        description: 'Données de connexion'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - email
+                - password
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: john.doe@example.com
+                password:
+                  type: string
+                  format: password
+                  example: Password123!
+              type: object
+      responses:
+        200:
+          description: 'Connexion réussie'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Connexion réussie.'
+                  data:
+                    properties:
+                      user:
+                        $ref: '#/components/schemas/User'
+                      token:
+                        type: string
+                        example: 1|a1b2c3d4e5f6g7h8i9j0...
+                      token_type:
+                        type: string
+                        example: Bearer
+                    type: object
+                type: object
+        401:
+          description: 'Email ou mot de passe invalide'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Email ou mot de passe invalide'
+                  errors:
+                    type: object
+                    nullable: true
+                type: object
+  /api/auth/logout:
+    post:
+      tags:
+        - Authentication
+      summary: 'Déconnexion utilisateur'
+      operationId: 88e8ba244c99f969290e8a8550cf839f
+      responses:
+        200:
+          description: 'Déconnexion réussie'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Déconnexion réussie.'
+                type: object
+  /api/auth/me:
+    get:
+      tags:
+        - Authentication
+      summary: "Récupérer les informations de l'utilisateur connecté"
+      operationId: 9cdf6d7f0d1076f420e43b051bcb065c
+      responses:
+        200:
+          description: 'Informations utilisateur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                type: object
+  /api/auth/refresh-token:
+    post:
+      tags:
+        - Authentication
+      summary: 'Rafraîchir le token'
+      operationId: c30aadf3ff6455d85fd93b1fb7ac4603
+      responses:
+        200:
+          description: 'Token rafraîchi'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Token rafraîchi'
+                  data:
+                    type: object
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  /api/auth/register:
+    post:
+      tags:
+        - Authentication
+      summary: 'Inscription utilisateur'
+      operationId: c2ccd6d98f1383d0449627059ecd0c4a
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - email
+                - password
+                - password_confirmation
+              properties:
+                name:
+                  type: string
+                  example: 'John Doe'
+                email:
+                  type: string
+                  format: email
+                  example: john.doe@example.com
+                password:
+                  type: string
+                  format: password
+                  example: Password123!
+                password_confirmation:
+                  type: string
+                  format: password
+                  example: Password123!
+              type: object
+      responses:
+        201:
+          description: 'Inscription réussie'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Inscription réussie'
+                  data:
+                    properties:
+                      user:
+                        $ref: '#/components/schemas/User'
+                      token:
+                        type: string
+                        example: 1|a1b2c3d4e5f6...
+                      token_type:
+                        type: string
+                        example: Bearer
+                    type: object
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error422'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  '/api/campaigns/type/{typeId}':
+    get:
+      tags:
+        - Campaigns
+      summary: 'Lister les campagnes par type'
+      description: "Retourne les campagnes correspondant à un type spécifique. Les campagnes sont filtrées selon les permissions de l'utilisateur connecté."
+      operationId: 2e8b9842ad77c77b249924447b26b9a8
+      parameters:
+        -
+          name: typeId
+          in: path
+          description: 'ID du type de campagne'
+          required: true
+          schema:
+            type: integer
+            example: 2
+      responses:
+        200:
+          description: 'Campagnes récupérées avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 3
+                    type: object
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'Type de campagne introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaigns/search:
+    get:
+      tags:
+        - Campaigns
+      summary: 'Lister les campagnes selon des critères'
+      description: 'Retourne les campagnes filtrées selon les critères passés en query params.'
+      operationId: 16756c03de40dbd28d7ce08a0b670428
+      parameters:
+        -
+          name: status
+          in: query
+          description: 'Filtrer par statut de campagne'
+          required: false
+          schema:
+            type: string
+            example: active
+        -
+          name: type_campaign_id
+          in: query
+          description: 'Filtrer par type de campagne'
+          required: false
+          schema:
+            type: integer
+            example: 2
+        -
+          name: is_published
+          in: query
+          description: 'Filtrer par publication'
+          required: false
+          schema:
+            type: boolean
+            example: true
+      responses:
+        200:
+          description: 'Campagnes récupérées avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 5
+                    type: object
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'La requête est invalide ou mal formée'
+                errors: []
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource'
+                errors: []
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de consulter ces campagnes"
+                errors: []
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur de serveur est survenue'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaigns/{id}':
+    get:
+      tags:
+        - Campaigns
+      summary: 'Afficher une campagne'
+      description: "Retourne les détails d'une campagne spécifique par son ID."
+      operationId: 5039bf095f984717e4bf75f92d9a5d13
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la campagne'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Détails de la campagne récupérés avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Non autorisé à accéder à cette ressource'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'Campagne introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    put:
+      tags:
+        - Campaigns
+      summary: 'Mettre à jour une campagne'
+      description: 'Met à jour une campagne existante appartenant à l’utilisateur connecté (ou accessible par un admin).'
+      operationId: 509d20710d9307eeb1a18100a7140201
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la campagne à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      requestBody:
+        description: 'Données à mettre à jour pour la campagne'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - description
+                - type_campaign_id
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  example: 'Nom mis à jour de la campagne'
+                description:
+                  type: string
+                  maxLength: 1000
+                  example: 'Nouvelle description de la campagne'
+                type_campaign_id:
+                  type: integer
+                  example: 2
+                status:
+                  type: string
+                  example: active
+                  nullable: true
+                is_published:
+                  type: boolean
+                  example: true
+                social_posts:
+                  description: 'Liste optionnelle de posts associés'
+                  type: array
+                  items:
+                    type: string
+                    example: 'Contenu modifié d’un post social'
+              type: object
+      responses:
+        200:
+          description: 'Campagne mise à jour avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignResource'
+                type: object
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'Campagne introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides.'
+                errors:
+                  name:
+                    - 'Le nom de la campaign est obligatoire.'
+                  description:
+                    - 'La description de la campagne ne dépasse pas 1000 caractères'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    delete:
+      tags:
+        - Campaigns
+      summary: 'Supprimer une campagne'
+      description: 'Supprime une campagne existante appartenant à l’utilisateur connecté (ou accessible par un admin).'
+      operationId: 2423d69c99369440246dff4532a4d26c
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la campagne à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      responses:
+        200:
+          description: 'Campagne supprimée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'La requête est invalide'
+                errors: []
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaigns/generate-name:
+    post:
+      tags:
+        - Campaigns
+      summary: 'Générer une campagne depuis une description'
+      description: 'Crée une campagne basée sur la description fournie et retourne la campagne générée.'
+      operationId: 0b639227e5fab199cbc953d81bab0bc7
+      requestBody:
+        description: 'Données pour générer la campagne'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - description
+                - type_campaign_id
+                - user_id
+              properties:
+                description:
+                  type: string
+                  example: 'Nouvelle campagne marketing'
+                type_campaign_id:
+                  type: integer
+                  example: 2
+                user_id:
+                  type: integer
+                  example: 10
+              type: object
+      responses:
+        200:
+          description: 'Campagne générée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  campaign:
+                    description: 'Campagne générée'
+                    properties:
+                      id:
+                        type: integer
+                        example: 15
+                      name:
+                        type: string
+                        example: 'Campagne générée automatiquement'
+                      description:
+                        type: string
+                        example: 'Nouvelle campagne marketing'
+                      type_campaign_id:
+                        type: integer
+                        example: 2
+                      user_id:
+                        type: integer
+                        example: 10
+                      status:
+                        type: string
+                        example: created
+                      is_published:
+                        type: boolean
+                        example: false
+                    type: object
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'La requête est invalide ou mal formée'
+                errors:
+                  description:
+                    - 'Le champ description est obligatoire.'
+                  type_campaign_id:
+                    - 'Type de campagne invalide.'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides.'
+                errors:
+                  description:
+                    - 'Le champ description est obligatoire.'
+                  user_id:
+                    - 'Utilisateur inexistant.'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaigns:
+    get:
+      tags:
+        - Campaigns
+      summary: 'Lister les campagnes'
+      description: 'Retourne toutes les campagnes (si admin) ou celles de l’utilisateur connecté.'
+      operationId: bd90d8c4fcb60dc0d4bd593a520df74c
+      responses:
+        200:
+          description: 'Liste des campagnes récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 5
+                    type: object
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Non autorisé à accéder à cette ressource'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    post:
+      tags:
+        - Campaigns
+      summary: 'Créer une campagne'
+      description: 'Crée une nouvelle campagne pour l’utilisateur connecté.'
+      operationId: de192e4e5da23d069fb089f061cae012
+      requestBody:
+        description: 'Données nécessaires pour créer une campagne'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - description
+                - type_campaign_id
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  example: 'Nouvelle campagne marketing'
+                description:
+                  type: string
+                  maxLength: 1000
+                  example: 'Description complète de la campagne'
+                type_campaign_id:
+                  type: integer
+                  example: 2
+                status:
+                  type: string
+                  example: created
+                  nullable: true
+                is_published:
+                  type: boolean
+                  example: false
+                social_posts:
+                  description: 'Liste optionnelle de posts associés'
+                  type: array
+                  items:
+                    type: string
+                    example: 'Contenu d’un post social'
+              type: object
+      responses:
+        201:
+          description: 'Campagne créée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignResource'
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides.'
+                errors:
+                  name:
+                    - 'Le nom de la campagne est obligatoire.'
+                  description:
+                    - 'La description de la campagne est obligatoire.'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaigns/template:
+    post:
+      tags:
+        - Campaigns
+      summary: "Créer une campagne à partir d'un template"
+      description: 'Crée une nouvelle campagne en utilisant un template existant et crée éventuellement des social posts associés.'
+      operationId: dcc43de0afcc38841f8ca8550ca4c5dd
+      requestBody:
+        description: 'Données nécessaires pour créer la campagne avec template'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - description
+                - type_campaign_id
+                - template_id
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                  example: 'Nouvelle campagne avec template'
+                description:
+                  type: string
+                  maxLength: 1000
+                  example: 'Description complète de la campagne'
+                type_campaign_id:
+                  type: integer
+                  example: 2
+                template_id:
+                  type: integer
+                  example: 5
+                status:
+                  type: string
+                  example: created
+                  nullable: true
+                is_published:
+                  type: boolean
+                  example: false
+                social_posts:
+                  description: 'Liste optionnelle de posts sociaux à créer avec la campagne'
+                  type: array
+                  items:
+                    properties:
+                      content:
+                        type: string
+                        example: 'Contenu du post social'
+                      social:
+                        properties:
+                          id:
+                            type: integer
+                            example: 1
+                        type: object
+                    type: object
+              type: object
+      responses:
+        201:
+          description: 'Campagne créée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignResource'
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides'
+                errors:
+                  name:
+                    - 'Le nom de la campagne est obligatoire.'
+                  description:
+                    - 'La description est obligatoire.'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaigns/user/{userId}':
+    get:
+      tags:
+        - Campaigns
+      summary: "Récupérer les campagnes d'un utilisateur"
+      description: 'Retourne la liste des campagnes appartenant à un utilisateur spécifique'
+      operationId: 8e69873fcebc30bfd9fe158e731e6508
+      parameters:
+        -
+          name: userId
+          in: path
+          description: "ID de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 10
+      responses:
+        200:
+          description: 'Campagnes récupérées avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 5
+                    type: object
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'Utilisateur non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaigns/popular/content:
+    get:
+      tags:
+        - Campaigns
+      summary: 'Récupérer les campagnes populaires'
+      description: 'Retourne la liste des campagnes populaires avec leurs statistiques'
+      operationId: 5b3bc3638a88567652213b601682fa6b
+      responses:
+        200:
+          description: 'Liste des campagnes populaires récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PopularCampaignResourceSchema'
+                  totals:
+                    properties:
+                      total_views:
+                        type: integer
+                        example: 5000
+                      total_likes:
+                        type: integer
+                        example: 350
+                    type: object
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaign-features/search:
+    get:
+      tags:
+        - CampaignFeatures
+      summary: 'Récupérer les CampaignFeatures selon des critères'
+      description: 'Retourne la liste des CampaignFeatures filtrée par les critères passés en query. Les utilisateurs non admin ne voient que leurs propres CampaignFeatures.'
+      operationId: e3fbdc9bef2982b6d6691ab64bc61607
+      parameters:
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID de campagne'
+          schema:
+            type: integer
+            example: 10
+        -
+          name: feature_id
+          in: query
+          description: 'Filtrer par ID de feature'
+          schema:
+            type: integer
+            example: 3
+      responses:
+        200:
+          description: 'Liste des CampaignFeatures récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignFeaturesResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaign-features/{id}':
+    get:
+      tags:
+        - CampaignFeatures
+      summary: 'Afficher une CampaignFeature'
+      description: "Retourne les détails d'une CampaignFeature spécifique par son ID."
+      operationId: 1b7d874e362e45be0b2a6d1719e290ff
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la CampaignFeature à récupérer'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      responses:
+        200:
+          description: 'CampaignFeature récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignFeaturesResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'CampaignFeature introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    put:
+      tags:
+        - CampaignFeatures
+      summary: 'Mettre à jour une CampaignFeature'
+      description: "Met à jour les informations d'une CampaignFeature existante."
+      operationId: 81adae49d762688649a081c94f0ddfc6
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la CampaignFeature à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      requestBody:
+        description: 'Données à mettre à jour pour la CampaignFeature'
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                campaign_id:
+                  type: integer
+                  example: 10
+                feature_id:
+                  type: integer
+                  example: 3
+              type: object
+      responses:
+        200:
+          description: 'CampaignFeature mise à jour avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignFeaturesResource'
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    delete:
+      tags:
+        - CampaignFeatures
+      summary: 'Supprimer une CampaignFeature'
+      description: "Supprime une CampaignFeature par son ID. Seul l'utilisateur autorisé peut effectuer cette action."
+      operationId: 7115f34085bb1d73673d5be079bd8391
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la CampaignFeature à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'CampaignFeature supprimée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'CampaignFeature introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaign-features:
+    get:
+      tags:
+        - CampaignFeatures
+      summary: 'Lister toutes les CampaignFeatures'
+      description: 'Retourne la liste complète des CampaignFeatures. Les utilisateurs non admin ne voient que leurs propres CampaignFeatures.'
+      operationId: getCampaignFeatures
+      parameters:
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID de campagne'
+          schema:
+            type: integer
+            example: 10
+        -
+          name: feature_id
+          in: query
+          description: 'Filtrer par ID de feature'
+          schema:
+            type: integer
+            example: 3
+      responses:
+        200:
+          description: 'Liste des CampaignFeatures récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignFeaturesResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    post:
+      tags:
+        - CampaignFeatures
+      summary: 'Créer une nouvelle CampaignFeature'
+      description: 'Crée une nouvelle CampaignFeature pour une campagne spécifique.'
+      operationId: createCampaignFeature
+      requestBody:
+        description: 'Données nécessaires pour créer une CampaignFeature'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - campaign_id
+                - feature_id
+              properties:
+                campaign_id:
+                  type: integer
+                  example: 10
+                feature_id:
+                  type: integer
+                  example: 3
+              type: object
+      responses:
+        201:
+          description: 'CampaignFeature créée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignFeaturesResource'
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides'
+                errors:
+                  campaign_id:
+                    - 'La campagne spécifiée est introuvable.'
+                  feature_id:
+                    - 'La fonctionnalité sélectionnée est invalide.'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaign-interactions/search:
+    get:
+      tags:
+        - 'Campaign Interactions'
+      summary: "Lister les interactions d'une campagne selon des critères"
+      description: 'Récupère une liste des interactions (vues, likes, partages, etc.) filtrées par critères fournis en query params.'
+      operationId: 3e1b8da1a5e6c1b50eee30f62f924721
+      parameters:
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par identifiant de la campagne'
+          required: false
+          schema:
+            type: integer
+            example: 12
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par identifiant de l’utilisateur'
+          required: false
+          schema:
+            type: integer
+            example: 45
+        -
+          name: type
+          in: query
+          description: 'Type d’interaction (view, like, share…)'
+          required: false
+          schema:
+            type: string
+            example: like
+      responses:
+        200:
+          description: 'Liste des interactions trouvées selon les critères'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignInteractionResource'
+                  meta:
+                    properties:
+                      total_interactions:
+                        type: integer
+                        example: 50
+                      total_views:
+                        type: integer
+                        example: 1200
+                      total_likes:
+                        type: integer
+                        example: 300
+                      total_shares:
+                        type: integer
+                        example: 75
+                    type: object
+                type: object
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaign-interactions/delete:
+    delete:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Supprimer une interaction par campagne et utilisateur'
+      description: "Supprime une interaction spécifique associée à un utilisateur et une campagne.\n *     Nécessite que la combinaison (campaign_id, user_id) existe."
+      operationId: d21496e4340a1f41529e73c251a69be8
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - campaign_id
+                - user_id
+              properties:
+                campaign_id:
+                  description: 'Identifiant de la campagne'
+                  type: integer
+                  example: 12
+                user_id:
+                  description: 'Identifiant de l’utilisateur'
+                  type: integer
+                  example: 45
+              type: object
+      responses:
+        200:
+          description: 'Interaction supprimée avec succès'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                message: 'Interaction supprimée avec succès'
+        404:
+          description: 'Aucune interaction trouvée pour ce couple campaign_id / user_id'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                message: 'Aucune interaction trouvée pour ce couple campaign_id / user_id'
+        400:
+          description: 'Requête invalide (paramètres manquants ou invalides)'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                error: 'Le champ campaign_id est requis et doit être un entier valide'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                error: Unauthenticated
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                error: 'Vous n’avez pas la permission de supprimer cette interaction'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                error: 'Erreur interne du serveur, veuillez réessayer plus tard'
+  '/api/campaign-interactions/{id}':
+    get:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Afficher une interaction spécifique'
+      description: "Retourne les détails d'une interaction utilisateur avec une campagne."
+      operationId: e1c97de4bfa005e30d2c216cc43d5513
+      parameters:
+        -
+          name: id
+          in: path
+          description: "Identifiant de l'interaction"
+          required: true
+          schema:
+            type: integer
+            example: 101
+      responses:
+        200:
+          description: 'Interaction récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CampaignInteractionResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    put:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Mettre à jour une interaction existante'
+      description: "Met à jour les informations d'une interaction spécifique (like, view, share, etc.) d'une campagne."
+      operationId: 83ffe30fa66ff45119a0182f502b14da
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'interaction à mettre à jour"
+          required: true
+          schema:
+            type: integer
+            example: 101
+      requestBody:
+        description: "Données de l'interaction à mettre à jour"
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                type:
+                  type: string
+                  example: share
+                likes:
+                  type: integer
+                  example: 2
+                views:
+                  type: integer
+                  example: 15
+                shares:
+                  type: integer
+                  example: 3
+              type: object
+      responses:
+        200:
+          description: 'Interaction mise à jour avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignInteractionResource'
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Les données fournies sont invalides'
+                errors:
+                  likes:
+                    - 'Le nombre de likes doit être un entier positif.'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+    delete:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Supprimer une interaction par ID'
+      description: 'Supprime une interaction spécifique grâce à son identifiant unique.'
+      operationId: f35d5c243e3390bfc5473ee36602a97b
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'Identifiant de l’interaction'
+          required: true
+          schema:
+            type: integer
+            example: 101
+      responses:
+        200:
+          description: 'Interaction supprimée avec succès'
+          content:
+            application/json:
+              schema: []
+              example:
+                message: 'Interaction supprimée avec succès'
+        404:
+          description: 'Interaction non trouvée'
+          content:
+            application/json:
+              schema: []
+              example:
+                error: 'Aucune interaction trouvée avec cet identifiant'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema: []
+              example:
+                error: Unauthenticated
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema: []
+              example:
+                error: 'Vous n’avez pas la permission de supprimer cette interaction'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema: []
+              example:
+                error: 'Erreur interne du serveur, veuillez réessayer plus tard'
+  /api/campaign-interactions:
+    get:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Lister toutes les interactions'
+      description: 'Retourne la liste complète des interactions disponibles.'
+      operationId: 0f5fe25ed6c9560143011581fdd3a7d8
+      responses:
+        200:
+          description: 'Liste des interactions récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignInteractionResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 120
+                    type: object
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+    post:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Créer une nouvelle interaction pour une campagne'
+      description: 'Crée une interaction (like, view, share, etc.) pour une campagne spécifique.'
+      operationId: 0d88ae939731e1a172b5eaf8a2c203aa
+      requestBody:
+        description: "Données de l'interaction à créer"
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - campaign_id
+                - user_id
+                - type
+              properties:
+                campaign_id:
+                  type: integer
+                  example: 12
+                user_id:
+                  type: integer
+                  example: 45
+                type:
+                  type: string
+                  example: like
+              type: object
+      responses:
+        201:
+          description: 'Interaction créée avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignInteractionResource'
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Les données fournies sont invalides'
+                errors:
+                  type:
+                    - "Le champ type doit être 'like', 'view' ou 'share'."
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaign-interactions/{interactionId}/like':
+    post:
+      tags:
+        - 'Campaign Interactions'
+      summary: 'Ajouter un like à une interaction'
+      description: 'Incrémente le compteur de likes pour une interaction spécifique.'
+      operationId: 8075fab4c221b05e60f37654e6a34eb8
+      parameters:
+        -
+          name: interactionId
+          in: path
+          description: "Identifiant de l'interaction"
+          required: true
+          schema:
+            type: integer
+            example: 101
+      responses:
+        200:
+          description: 'Like ajouté avec succès'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                message: 'Like ajouté avec succès'
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Impossible d'ajouter un like"
+                errors:
+                  interactionId:
+                    - "L'identifiant fourni est invalide."
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaign-interactions/{campaignId}/stats':
+    get:
+      tags:
+        - 'Campaign Interactions'
+      summary: "Récupérer les statistiques d'interactions d'une campagne"
+      description: 'Retourne le nombre total de likes, vues et partages pour une campagne spécifique.'
+      operationId: 288da0b1db6f40ba97b0043b1077e7c7
+      parameters:
+        -
+          name: campaignId
+          in: path
+          description: 'Identifiant de la campagne'
+          required: true
+          schema:
+            type: integer
+            example: 12
+      responses:
+        200:
+          description: 'Statistiques récupérées avec succès'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                likes: 120
+                views: 1500
+                shares: 45
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/campaign-templates:
+    get:
+      tags:
+        - 'Campaign Templates'
+      summary: 'Lister tous les modèles de campagnes avec stats'
+      description: "Retourne la liste de tous les modèles de campagnes avec le rating et le nombre d'utilisations."
+      operationId: 68c38799d766102e5b705322c6f2822d
+      responses:
+        200:
+          description: 'Liste des templates récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/CampaignTemplateResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaign-templates/{id}':
+    get:
+      tags:
+        - 'Campaign Templates'
+      summary: 'Récupérer un modèle de campagne spécifique avec stats'
+      description: "Retourne un modèle de campagne avec ses statistiques (rating, nombre d'utilisations)."
+      operationId: 8ae915c1acc4c6ae9802e941fc8e7256
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du template de campagne'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Template récupéré avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampaignTemplateResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        400:
+          description: 'Template introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  /api/categories:
+    get:
+      tags:
+        - 'Campaign Templates'
+      summary: 'Récupérer la liste des catégories'
+      description: 'Retourne toutes les catégories disponibles avec leurs icônes.'
+      operationId: 2165556c1747769e899a825592d1ed05
+      responses:
+        200:
+          description: 'Liste des catégories récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    name:
+                      description: 'Nom de la catégorie'
+                      type: string
+                      example: Marketing
+                    icon:
+                      description: "Nom ou chemin de l'icône"
+                      type: string
+                      example: marketing-icon
+                  type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+      security:
+        -
+          bearerAuth: []
+  '/api/campaign-templates/{templateId}/rating':
+    post:
+      tags:
+        - 'Campaign Templates'
+      summary: "Ajouter ou mettre à jour le rating d'un template"
+      description: 'Permet à un utilisateur de créer ou modifier son rating pour un template donné.'
+      operationId: 17bf227bd53a765bc0bf10db818732f4
+      parameters:
+        -
+          name: templateId
+          in: path
+          description: 'ID du template'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                rating:
+                  type: number
+                  example: 4.5
+              type: object
+      responses:
+        200:
+          description: 'Rating enregistré avec succès'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: true
+                message: 'Rating enregistré avec succès'
+                data:
+                  template_id: 7
+                  user_id: 12
+                  rating: 4.5
+        400:
+          description: 'Requête invalide'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Rating invalide ou manquant'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        422:
+          description: 'Erreur de validation des champs'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Les données fournies sont invalides.'
+                errors:
+                  rating:
+                    - 'Le champ rating doit être un nombre entre 0 et 5.'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+      security:
+        -
+          bearerAuth: []
+  '/api/dashboard/indicators/{userId}':
+    get:
+      tags:
+        - Dashboard
+      summary: 'Récupérer les indicateurs du dashboard pour un utilisateur'
+      description: "Retourne les statistiques des campagnes et interactions d'un utilisateur, y compris les indicateurs globaux et ceux venant d'autres utilisateurs."
+      operationId: 3189df42c267a83950415e5dc949dd6a
+      parameters:
+        -
+          name: userId
+          in: path
+          description: "Identifiant de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 45
+      responses:
+        200:
+          description: 'Indicateurs récupérés avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    properties:
+                      totalCampaigns:
+                        type: integer
+                        example: 10
+                      totalViews:
+                        type: integer
+                        example: 1200
+                      totalLikes:
+                        type: integer
+                        example: 300
+                      totalShares:
+                        type: integer
+                        example: 75
+                      engagementRate:
+                        type: number
+                        format: float
+                        example: 31.3
+                      externalInteractions:
+                        properties:
+                          views:
+                            type: integer
+                            example: 800
+                          likes:
+                            type: integer
+                            example: 150
+                          shares:
+                            type: integer
+                            example: 20
+                        type: object
+                    type: object
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous devez être connecté pour accéder à cette ressource'
+                  errors:
+                    type: object
+                    example: []
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Vous n'avez pas la permission d'accéder à cette ressource"
+                  errors:
+                    type: object
+                    example: []
+                type: object
+        404:
+          description: 'Utilisateur introuvable'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Utilisateur non trouvé'
+                  errors:
+                    type: object
+                    example: []
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Une erreur de serveur est survenue'
+                type: object
+      security:
+        -
+          bearerAuth: []
+  /api/email/verification-status:
+    get:
+      tags:
+        - 'Email Verification'
+      summary: "Statut de vérification de l'email"
+      description: "Retourne le statut de vérification de l'email de l'utilisateur connecté"
+      operationId: 8684191a544aa439d62a34d4423080bd
+      responses:
+        200:
+          description: 'Statut récupéré avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  verified:
+                    type: boolean
+                    example: false
+                  email:
+                    type: string
+                    example: john.doe@example.com
+                  verified_at:
+                    type: string
+                    format: date-time
+                    nullable: true
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de consulter ce statut"
+        404:
+          description: 'Utilisateur introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Utilisateur non trouvé'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue'
+      security:
+        -
+          bearerAuth: []
+  /api/email/send-verification:
+    post:
+      tags:
+        - 'Email Verification'
+      summary: 'Envoyer email de vérification'
+      description: "Envoie un email de vérification si l'email n'est pas encore vérifié"
+      operationId: 5825da9dad6aae7eb3b00342dfbbdbcf
+      responses:
+        200:
+          description: 'Email de vérification envoyé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Email de vérification envoyé.'
+                type: object
+        400:
+          description: 'Requête invalide ou email déjà vérifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "L'email est déjà vérifié"
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté'
+        403:
+          description: 'Accès interdit'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission d'envoyer cet email"
+        404:
+          description: 'Utilisateur introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Utilisateur non trouvé'
+        429:
+          description: 'Trop de requêtes (rate limit)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Trop de tentatives, veuillez réessayer plus tard'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue'
+      security:
+        -
+          bearerAuth: []
+  /api/email/verify:
+    post:
+      tags:
+        - 'Email Verification'
+      summary: "Vérifier l'email"
+      description: "Vérifie l'email à partir des paramètres du lien de vérification"
+      operationId: 11a3d0bea7a972dbe9605259e008eb20
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - id
+                - hash
+                - expires
+                - signature
+              properties:
+                id:
+                  type: integer
+                  example: 1
+                hash:
+                  type: string
+                  example: abc123hash
+                expires:
+                  type: integer
+                  example: 1700000000
+                signature:
+                  type: string
+                  example: signatureexample
+              type: object
+      responses:
+        200:
+          description: 'Email vérifié avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Email vérifié avec succès.'
+                  data:
+                    properties:
+                      user:
+                        $ref: '#/components/schemas/User'
+                      token:
+                        type: string
+                        example: 1|a1b2c3...
+                      token_type:
+                        type: string
+                        example: Bearer
+                    type: object
+                type: object
+        400:
+          description: 'Lien invalide, expiré ou email déjà vérifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Le lien de vérification est invalide ou a expiré.'
+        404:
+          description: 'Utilisateur introuvable'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Aucun utilisateur trouvé pour l'ID fourni."
+        409:
+          description: 'Email déjà vérifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Cet email est déjà vérifié.'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue, veuillez réessayer plus tard.'
+  /api/features/search:
+    get:
+      tags:
+        - Features
+      summary: 'Rechercher des fonctionnalités selon des critères'
+      description: 'Filtre les Features par critères'
+      operationId: e8a01134d5bdc1911095625badc65026
+      parameters:
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par ID utilisateur'
+          required: false
+          schema:
+            type: integer
+            example: 2
+        -
+          name: name
+          in: query
+          description: 'Filtrer par nom de feature'
+          required: false
+          schema:
+            type: string
+            example: Campagne
+      responses:
+        200:
+          description: 'Résultats filtrés'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollection'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource'
+                errors: []
+        403:
+          description: 'Non autorisé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de rechercher ces fonctionnalités"
+                errors: []
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue, veuillez réessayer plus tard'
+                errors: []
+      security:
+        -
+          bearerAuth: []
+  '/api/features/{id}':
+    get:
+      tags:
+        - Features
+      summary: 'Voir une fonctionnalité'
+      description: "Retourne les détails d'un Feature selon son ID."
+      operationId: 41389c397159cab2129d317188cba5b0
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du Feature'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      responses:
+        200:
+          description: 'Feature trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: Unauthenticated
+        403:
+          description: 'Non autorisé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Accès interdit'
+        404:
+          description: 'Feature non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Feature introuvable'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Erreur serveur'
+      security:
+        -
+          bearerAuth: []
+    put:
+      tags:
+        - Features
+      summary: 'Mettre à jour une fonctionnalité'
+      description: 'Met à jour un Feature existant.'
+      operationId: cdaeaa8700e80afb005f68269278ef41
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du Feature'
+          required: true
+          schema:
+            type: integer
+            example: 8
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'Nom modifié'
+              type: object
+      responses:
+        200:
+          description: 'Feature mis à jour'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource'
+                errors: []
+        403:
+          description: 'Non autorisé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de modifier cette fonctionnalité"
+                errors: []
+        404:
+          description: 'Feature non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Aucune fonctionnalité trouvée avec l'ID fourni"
+                errors: []
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides'
+                errors:
+                  name:
+                    - 'Le champ name est obligatoire ou invalide'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue, veuillez réessayer plus tard'
+                errors: []
+      security:
+        -
+          bearerAuth: []
+    delete:
+      tags:
+        - Features
+      summary: 'Supprimer une fonctionnalité'
+      description: 'Supprime un Feature par son ID.'
+      operationId: bb46523e6ace08d58fbbe3cf118a4f2e
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du Feature'
+          required: true
+          schema:
+            type: integer
+            example: 10
+      responses:
+        200:
+          description: 'Supprimé avec succès'
+          content:
+            application/json:
+              schema: []
+              example:
+                message: 'Supprimé avec succès.'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Non autorisé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Feature non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        -
+          bearerAuth: []
+  /api/features:
+    get:
+      tags:
+        - Features
+      summary: 'Lister toutes les fonctionnalités'
+      description: 'Retourne la liste complète des Features disponibles.'
+      operationId: 22014dd9cc95707e3e38587872537275
+      responses:
+        200:
+          description: 'Liste des fonctionnalités récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureCollection'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource'
+                errors: []
+        403:
+          description: 'Non autorisé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de lister les fonctionnalités"
+                errors: []
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue, veuillez réessayer plus tard'
+                errors: []
+      security:
+        -
+          bearerAuth: []
+    post:
+      tags:
+        - Features
+      summary: 'Créer une nouvelle fonctionnalité'
+      description: 'Crée un Feature et le retourne.'
+      operationId: 4aa3c1825dd1415b6346fde7318d176d
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: 'Nouvelle fonctionnalité'
+              type: object
+      responses:
+        201:
+          description: 'Feature créée avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource'
+                errors: []
+        403:
+          description: 'Non autorisé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de créer une fonctionnalité"
+                errors: []
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Les données fournies sont invalides'
+                errors:
+                  name:
+                    - 'Le champ name est obligatoire ou trop long'
+                  other_field:
+                    - 'Valeur invalide pour other_field'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue, veuillez réessayer plus tard'
+                errors: []
+      security:
+        -
+          bearerAuth: []
+  /api/images/search:
+    get:
+      tags:
+        - Images
+      summary: 'Lister les images selon des critères'
+      description: 'Retourne une collection d’images filtrées par critères (par défaut limité à l’utilisateur connecté sauf si admin).'
+      operationId: 800d8e358356cd72cf9eac8a6f39e2bc
+      parameters:
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID de campagne'
+          required: false
+          schema:
+            type: integer
+            example: 5
+        -
+          name: is_published
+          in: query
+          description: 'Filtrer les images publiées ou non'
+          required: false
+          schema:
+            type: boolean
+            example: true
+      responses:
+        200:
+          description: 'Liste des images filtrées'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageCollection'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource'
+                errors: []
+        403:
+          description: 'Accès refusé (droits insuffisants)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de voir ces images"
+                errors: []
+        404:
+          description: 'Aucune image trouvée pour les critères fournis'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Aucune image correspondante trouvée'
+                errors: []
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue, veuillez réessayer plus tard'
+                errors: []
+  '/api/images/{id}':
+    get:
+      tags:
+        - Images
+      summary: 'Afficher une image'
+      description: "Retourne les détails d'une image spécifique par son ID."
+      operationId: 69e3d86c2990c0e02e6b18191289fb88
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'image à récupérer"
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: "Détails de l'image"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous devez être authentifié.'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Vous n'avez pas la permission de visualiser cette image."
+                type: object
+        404:
+          description: 'Image non trouvée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Image introuvable avec l'ID fourni."
+                type: object
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Erreur interne du serveur lors de la récupération de l'image."
+                type: object
+    put:
+      tags:
+        - Images
+      summary: 'Mettre à jour une image'
+      description: "Met à jour les informations d'une image spécifique."
+      operationId: 62e0e1597ac5c7c5cf899f71b0ee0cbc
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'image à mettre à jour"
+          required: true
+          schema:
+            type: integer
+            example: 7
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                path:
+                  type: string
+                  example: /images/updated.jpg
+              type: object
+      responses:
+        200:
+          description: 'Image mise à jour avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous devez être connecté pour effectuer cette action.'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous n’avez pas la permission de modifier cette image.'
+                type: object
+        404:
+          description: 'Image non trouvée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "L'image avec l'ID fourni est introuvable."
+                type: object
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Les données fournies sont invalides.'
+                  errors:
+                    properties:
+                      path:
+                        type: array
+                        items:
+                          type: string
+                          example: 'Le champ path doit être une URL valide.'
+                    type: object
+                type: object
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Erreur interne du serveur lors de la mise à jour de l'image."
+                type: object
+    delete:
+      tags:
+        - Images
+      summary: 'Supprimer une image'
+      description: 'Supprime une image spécifique par son ID.'
+      operationId: 3218989f90d604b52eafc0896857508d
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'image à supprimer"
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Image supprimée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Vous devez être connecté pour supprimer une image'
+                errors: []
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de supprimer cette image"
+                errors: []
+        404:
+          description: 'Image non trouvée'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Aucune image trouvée avec l'ID fourni"
+                errors: []
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Erreur interne du serveur lors de la suppression de l'image"
+                errors: []
+  /api/images/generate:
+    post:
+      tags:
+        - Images
+      summary: 'Générer une image'
+      description: "Génère une image à partir d'un prompt et l'associe à une campagne."
+      operationId: eb30f2fcc857ef2bfe2abce64d397e5b
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                prompt:
+                  type: string
+                  example: "Une illustration futuriste d'une ville"
+                campaign_id:
+                  type: integer
+                  example: 3
+                prompt_id:
+                  type: integer
+                  example: 12
+              type: object
+      responses:
+        200:
+          description: 'Image générée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Image générée avec succès'
+                  images:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ImageResource'
+                  data:
+                    properties:
+                      image:
+                        $ref: '#/components/schemas/ImageResource'
+                      image_url:
+                        type: string
+                        example: /images/example.jpg
+                    type: object
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Vous devez être connecté pour générer une image'
+                errors: []
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de générer une image pour cette campagne"
+                errors: []
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Données invalides'
+                errors:
+                  prompt:
+                    - 'Le champ prompt est obligatoire.'
+                  campaign_id:
+                    - 'Le champ campaign_id doit être un entier valide.'
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Erreur interne du serveur lors de la génération de l'image"
+                errors: []
+  /api/images:
+    get:
+      tags:
+        - Images
+      summary: 'Lister les images'
+      description: "Retourne la liste des images de l'utilisateur (ou toutes pour un admin)."
+      operationId: b1db8e9b7397657ba2386f050362885f
+      responses:
+        200:
+          description: 'Liste des images'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageCollection'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous devez être authentifié.'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Vous n'avez pas la permission de visualiser ces images."
+                type: object
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Erreur interne du serveur lors de la récupération des images.'
+                type: object
+    post:
+      tags:
+        - Images
+      summary: 'Créer une nouvelle image'
+      description: 'Crée une image pour une campagne.'
+      operationId: 20ac397f9cc6e51861705795d6e5fec5
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                path:
+                  type: string
+                  example: /images/example.jpg
+                campaign_id:
+                  type: integer
+                  example: 3
+                prompt_id:
+                  type: integer
+                  example: 12
+              type: object
+      responses:
+        201:
+          description: 'Image créée avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImageResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous devez être connecté pour accéder à cette ressource.'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous n’avez pas la permission de créer une image pour cette campagne.'
+                type: object
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Les données fournies sont invalides.'
+                  errors:
+                    properties:
+                      path:
+                        type: array
+                        items:
+                          type: string
+                          example: 'Le champ path est obligatoire.'
+                      campaign_id:
+                        type: array
+                        items:
+                          type: string
+                          example: 'La campagne spécifiée est introuvable.'
+                    type: object
+                type: object
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Erreur interne du serveur lors de la création de l'image."
+                type: object
+  /api/landing-pages/search:
+    get:
+      tags:
+        - LandingPages
+      summary: 'Lister les landing pages selon des critères'
+      description: 'Retourne la liste des landing pages filtrées selon les critères fournis. Les utilisateurs non-admin ne voient que leurs propres landing pages.'
+      operationId: 8c78b7aa5e96ab3f4c90cd6c42465ad9
+      parameters:
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par ID utilisateur (uniquement admin)'
+          required: false
+          schema:
+            type: integer
+            example: 3
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID campagne'
+          required: false
+          schema:
+            type: integer
+            example: 12
+      responses:
+        200:
+          description: 'Liste des landing pages'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LandingPageCollection'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur serveur inattendue'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Erreur interne du serveur lors de la récupération des landing pages.'
+                type: object
+  '/api/landing-pages/{id}':
+    get:
+      tags:
+        - LandingPages
+      summary: 'Afficher une landing page'
+      description: "Retourne les détails d'une landing page spécifique."
+      operationId: 1ee1a3ca162573a8f1fe4331230fc707
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la landing page'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Détails de la landing page'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/LandingPageResource'
+                type: object
+    put:
+      tags:
+        - LandingPages
+      summary: 'Mettre à jour une landing page'
+      description: "Met à jour le contenu d'une landing page spécifique."
+      operationId: 455b773e601f0d0fcb0726465906301c
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la landing page à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - content
+              properties:
+                content:
+                  type: object
+                  example:
+                    title: 'Nouvelle landing page'
+                    sections:
+                      header: Bienvenue
+                      footer: Contactez-nous
+              type: object
+      responses:
+        200:
+          description: 'Landing page mise à jour avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Landing page mise à jour avec succès'
+                  data:
+                    $ref: '#/components/schemas/LandingPageResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous devez être connecté pour accéder à cette ressource.'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous n’avez pas la permission de modifier cette landing page.'
+                type: object
+        404:
+          description: 'Landing page non trouvée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'La landing page demandée est introuvable.'
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Les données fournies sont invalides.'
+                  errors:
+                    type: object
+                    example:
+                      content:
+                        - 'Le champ content est obligatoire.'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Une erreur inattendue est survenue lors de la mise à jour de la landing page.'
+                type: object
+      security:
+        -
+          bearerAuth: []
+    delete:
+      tags:
+        - LandingPages
+      summary: 'Supprimer une landing page'
+      description: 'Supprime une landing page spécifique.'
+      operationId: 313f3c59a07c7aebbda23dcb63e2fcd6
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID de la landing page'
+          required: true
+          schema:
+            type: integer
+            example: 5
+      responses:
+        200:
+          description: 'Landing page supprimée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Landing page supprimée avec succès'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Landing page non trouvée'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Erreur interne du serveur lors de la suppression de la landing page'
+                type: object
+  /api/landing-pages/generate:
+    post:
+      tags:
+        - LandingPages
+      summary: 'Générer une landing page'
+      description: "Génère une landing page à partir d'un prompt pour une campagne spécifique."
+      operationId: 5141c9998ed0a03c4f157e516859710b
+      requestBody:
+        description: 'Données pour générer la landing page'
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                prompt:
+                  type: string
+                  example: 'Créer une landing page pour notre nouveau produit X.'
+                campaign_id:
+                  type: integer
+                  example: 12
+                prompt_id:
+                  type: integer
+                  example: 7
+              type: object
+      responses:
+        201:
+          description: 'Landing page générée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    properties:
+                      id:
+                        type: integer
+                        example: 1
+                      content:
+                        type: array
+                        items:
+                          type: string
+                          example:
+                            - 'Titre principal'
+                            - Sous-titre
+                            - CTA
+                      campaign_id:
+                        type: integer
+                        example: 12
+                      created_at:
+                        type: string
+                        format: date-time
+                        example: '2025-09-25 16:00:00'
+                    type: object
+                  message:
+                    type: string
+                    example: 'Landing page générée avec succès'
+                type: object
+        200:
+          description: 'Fallback utilisé suite à une erreur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                  fallback:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Landing page générée avec un template de base suite à une erreur'
+                type: object
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Validation failed'
+                  errors:
+                    type: object
+                    example:
+                      prompt:
+                        - 'Le champ prompt est requis'
+                      campaign_id:
+                        - 'Le champ campaign_id doit être un entier'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Erreur lors de la génération de la landing page'
+                  error:
+                    type: string
+                    example: "Détails de l'exception"
+                type: object
+  /api/landing-pages:
+    get:
+      tags:
+        - LandingPages
+      summary: 'Liste des landing pages'
+      description: 'Retourne la liste des landing pages, filtrable par `campaign_id`.'
+      operationId: 1005649cc3bae996ec46ff9e2997915b
+      parameters:
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID de campagne'
+          required: false
+          schema:
+            type: integer
+            example: 12
+      responses:
+        200:
+          description: 'Liste des landing pages'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LandingPageResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 5
+                    type: object
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Ressource non trouvée'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - LandingPages
+      summary: 'Créer une landing page'
+      description: 'Crée une nouvelle landing page pour une campagne spécifique.'
+      operationId: 8ac8710856b988c24c34b84f161c2f5e
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                content:
+                  type: array
+                  items:
+                    properties:
+                      type:
+                        type: string
+                        example: text
+                      value:
+                        type: string
+                        example: Bienvenue
+                    type: object
+                campaign_id:
+                  type: integer
+                  example: 5
+                prompt_id:
+                  type: integer
+                  example: 12
+              type: object
+      responses:
+        201:
+          description: 'Landing page créée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/LandingPageResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Validation failed'
+                  errors:
+                    properties:
+                      content:
+                        type: array
+                        items:
+                          type: string
+                          example: 'Le champ content est requis'
+                      campaign_id:
+                        type: array
+                        items:
+                          type: string
+                          example: 'Le champ campaign_id est requis'
+                    type: object
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/admin/payments:
+    get:
+      tags:
+        - Payments
+      summary: 'Lister tous les paiements'
+      description: 'Retourne la liste de tous les paiements avec les informations utilisateur et transaction.'
+      operationId: 97a1693187d15c906563e79a6f9a7eda
+      responses:
+        200:
+          description: 'Liste des paiements'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    id:
+                      type: integer
+                      example: 12
+                    username:
+                      type: string
+                      example: 'John Doe'
+                    amount:
+                      type: number
+                      format: float
+                      example: 5000
+                    currency:
+                      type: string
+                      example: Ar
+                    created_at:
+                      type: string
+                      format: date-time
+                      example: '2025-09-25 15:30:00'
+                    expiration_date:
+                      type: string
+                      format: date-time
+                      example: '2025-10-25 15:30:00'
+                    transaction_reference:
+                      type: string
+                      example: TRX123456789
+                  type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à cette ressource.'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Vous n'avez pas la permission d'accéder à ces paiements."
+        404:
+          description: 'Ressource non trouvée'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Aucun paiement trouvé.'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Erreur serveur interne'
+  /api/payments:
+    post:
+      tags:
+        - Payments
+      summary: 'Effectuer un paiement'
+      description: 'Crée un paiement pour un utilisateur et active le tarif correspondant.'
+      operationId: 87709b8d7bebf734964f44c658722416
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                amount:
+                  type: string
+                  example: '5000'
+                currency:
+                  type: string
+                  example: Ar
+                description:
+                  type: string
+                  example: 'Paiement Pro'
+                customer_msisdn:
+                  type: string
+                  example: '0341234567'
+                merchant_msisdn:
+                  type: string
+                  example: '0337654321'
+              type: object
+      responses:
+        200:
+          description: 'Paiement effectué avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  id:
+                    type: integer
+                    example: 12
+                  amount:
+                    type: number
+                    format: float
+                    example: 5000
+                  currency:
+                    type: string
+                    example: Ar
+                  transaction_reference:
+                    type: string
+                    example: TRX123456789
+                  created_at:
+                    type: string
+                    format: date-time
+                    example: '2025-09-25 15:30:00'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Vous devez être connecté pour effectuer un paiement.'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Vous n'avez pas la permission d'effectuer ce paiement."
+        404:
+          description: 'Ressource non trouvée'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Utilisateur ou tarif introuvable.'
+        500:
+          description: 'Erreur interne du serveur lors du paiement'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Payment error: Montant invalide'
+  /api/payments/user:
+    get:
+      tags:
+        - Payments
+      summary: "Lister les paiements de l'utilisateur connecté"
+      description: "Retourne la liste des paiements effectués par l'utilisateur connecté."
+      operationId: f0f08336376acc9a234f8503c304f84d
+      responses:
+        200:
+          description: "Liste des paiements de l'utilisateur"
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    amount:
+                      type: number
+                      format: float
+                      example: 5000
+                    currency:
+                      type: string
+                      example: Ar
+                    transaction_reference:
+                      type: string
+                      example: TRX123456789
+                    created_at:
+                      type: string
+                      format: date-time
+                      example: '2025-09-25 15:30:00'
+                  type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Vous devez être connecté pour accéder à vos paiements.'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: "Vous n'avez pas la permission de consulter ces paiements."
+        404:
+          description: 'Ressource non trouvée'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Aucun paiement trouvé pour cet utilisateur.'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                type: object
+              example:
+                success: false
+                message: 'Erreur serveur interne'
+  /api/password/reset:
+    post:
+      tags:
+        - PasswordReset
+      summary: 'Réinitialiser le mot de passe'
+      description: 'Réinitialise le mot de passe utilisateur avec un token de réinitialisation valide'
+      operationId: resetPassword
+      requestBody:
+        description: 'Données pour réinitialiser le mot de passe'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - token
+                - email
+                - password
+                - password_confirmation
+              properties:
+                token:
+                  type: string
+                  example: token123
+                email:
+                  type: string
+                  format: email
+                  example: user@example.com
+                password:
+                  type: string
+                  format: password
+                  example: NewPassword123!
+                password_confirmation:
+                  type: string
+                  format: password
+                  example: NewPassword123!
+              type: object
+      responses:
+        200:
+          description: 'Mot de passe réinitialisé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Mot de passe réinitialisé avec succès.'
+                type: object
+        422:
+          description: 'Données de validation invalides'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Les données fournies sont invalides.'
+                  errors:
+                    type: object
+                    example:
+                      email:
+                        - "L'adresse email est invalide."
+                      password:
+                        - 'Le mot de passe doit contenir au moins 8 caractères.'
+                        - 'Le mot de passe doit contenir au moins une lettre majuscule.'
+                        - 'Le mot de passe doit contenir au moins un chiffre.'
+                      password_confirmation:
+                        - 'La confirmation du mot de passe ne correspond pas.'
+                type: object
+        500:
+          description: 'Erreur serveur interne'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Une erreur interne est survenue. Veuillez réessayer plus tard.'
+                  errors:
+                    type: object
+                    example:
+                      server:
+                        - 'Erreur lors de la mise à jour du mot de passe.'
+                  debug:
+                    description: 'Informations de débogage (uniquement en environnement de développement)'
+                    type: object
+                    example: []
+                type: object
+  /api/password/email:
+    post:
+      tags:
+        - PasswordReset
+      summary: 'Envoyer un lien de réinitialisation du mot de passe'
+      description: "Envoie un email contenant un lien de réinitialisation de mot de passe à l'adresse spécifiée"
+      operationId: sendPasswordResetLink
+      requestBody:
+        description: 'Adresse email pour envoyer le lien'
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - email
+              properties:
+                email:
+                  description: "Adresse email de l'utilisateur"
+                  type: string
+                  format: email
+                  example: user@example.com
+              type: object
+      responses:
+        200:
+          description: 'Lien de réinitialisation envoyé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Lien de réinitialisation envoyé par email.'
+                type: object
+        422:
+          description: 'Données de validation invalides'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Les données fournies sont invalides.'
+                  errors:
+                    type: object
+                    example:
+                      email:
+                        - 'Le champ email est obligatoire.'
+                        - "L'adresse email doit être une adresse email valide."
+                        - "L'adresse email n'existe pas dans notre système."
+                        - "Nous ne pouvons pas envoyer d'email à cette adresse."
+                        - 'Trop de tentatives. Veuillez réessayer dans 5 minutes.'
+                type: object
+        500:
+          description: 'Erreur serveur interne'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Une erreur est survenue lors de l'envoi de l'email. Veuillez réessayer."
+                  errors:
+                    type: object
+                    example:
+                      server:
+                        - "Impossible d'envoyer l'email de réinitialisation."
+                        - "Erreur de connexion au service d'email."
+                        - "Service d'email temporairement indisponible."
+                type: object
+  /api/prompts/search:
+    get:
+      tags:
+        - Prompts
+      summary: 'Lister les prompts selon des critères'
+      description: "Retourne la liste des prompts filtrés selon les critères passés en query. Si l'utilisateur n'est pas admin, il ne verra que ses propres prompts."
+      operationId: searchPrompts
+      parameters:
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID de campagne'
+          required: false
+          schema:
+            type: integer
+            example: 5
+        -
+          name: user_id
+          in: query
+          description: "Filtrer par ID d'utilisateur (admin uniquement)"
+          required: false
+          schema:
+            type: integer
+            example: 12
+        -
+          name: search
+          in: query
+          description: 'Recherche textuelle dans le titre et le contenu'
+          required: false
+          schema:
+            type: string
+            example: marketing
+        -
+          name: page
+          in: query
+          description: 'Numéro de page'
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            example: 1
+        -
+          name: per_page
+          in: query
+          description: "Nombre d'éléments par page"
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            minimum: 1
+            example: 20
+      responses:
+        200:
+          description: 'Liste des prompts'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PromptResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 10
+                      current_page:
+                        type: integer
+                        example: 1
+                      last_page:
+                        type: integer
+                        example: 1
+                      per_page:
+                        type: integer
+                        example: 20
+                      from:
+                        type: integer
+                        example: 1
+                      to:
+                        type: integer
+                        example: 10
+                    type: object
+                type: object
+        400:
+          description: 'Paramètres invalides'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error400'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error401'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error403'
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
+  '/api/prompts/{id}':
+    get:
+      tags:
+        - Prompts
+      summary: 'Afficher un prompt'
+      description: "Retourne les détails d'un prompt spécifique."
+      operationId: 7a23a6856e94c5d4fb4a4a79c330ed95
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du prompt'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Détails du prompt'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Prompt non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - Prompts
+      summary: 'Mettre à jour un prompt'
+      description: "Met à jour le contenu d'un prompt spécifique."
+      operationId: 37f838e7dbd490382cba9c4f4707a6db
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du prompt'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                content:
+                  type: string
+                  example: 'Nouveau contenu du prompt'
+              type: object
+      responses:
+        200:
+          description: 'Prompt mis à jour avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Prompt non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - Prompts
+      summary: 'Supprimer un prompt'
+      description: 'Supprime un prompt spécifique par ID. Seul le propriétaire ou un administrateur peut supprimer un prompt.'
+      operationId: deletePrompt
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du prompt à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Prompt supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Prompt supprimé avec succès.'
+                  data:
+                    type: object
+                    example: []
+                type: object
+        401:
+          description: 'Non authentifié - Token manquant ou invalide'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Token d'authentification invalide"
+                type: object
+        403:
+          description: 'Accès refusé - Pas le propriétaire du prompt'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: "Vous n'êtes pas autorisé à supprimer ce prompt"
+                type: object
+        404:
+          description: 'Prompt non trouvé - ID invalide'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Aucun prompt trouvé avec cet ID'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Erreur serveur lors de la suppression'
+                type: object
+  /api/prompts/index:
+    get:
+      tags:
+        - Prompts
+      summary: 'Lister tous les prompts'
+      description: 'Retourne la liste de tous les prompts.'
+      operationId: 2b8486e8248d293967556665d40131eb
+      responses:
+        200:
+          description: 'Liste des prompts'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PromptResource'
+                  total:
+                    type: integer
+                    example: 15
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Non authentifié'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Vous n’avez pas les permissions nécessaires pour accéder à cette ressource'
+                errors: []
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                success: false
+                message: 'Une erreur interne est survenue lors de la récupération des campagnes'
+  '/api/prompts/quota/{userId}':
+    get:
+      tags:
+        - Prompts
+      summary: 'Obtenir le quota de prompts utilisé par un utilisateur'
+      description: "Retourne le nombre de prompts utilisés aujourd'hui par un utilisateur donné."
+      operationId: 53a0b19d1a342e45b5ab0edef1165ba0
+      parameters:
+        -
+          name: userId
+          in: path
+          description: "ID de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 12
+      responses:
+        200:
+          description: 'Quota de prompts utilisé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    properties:
+                      user_id:
+                        type: integer
+                        example: 12
+                      daily_quota_used:
+                        type: integer
+                        example: 5
+                    type: object
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/prompts:
+    post:
+      tags:
+        - Prompts
+      summary: 'Créer un prompt'
+      description: 'Crée un nouveau prompt pour une campagne spécifique.'
+      operationId: 9080668a27b80154f045d195d4f1bcef
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                content:
+                  type: string
+                  example: 'Créer un prompt pour campagne X'
+                campaign_id:
+                  type: integer
+                  example: 5
+                prompt_id:
+                  type: integer
+                  example: 12
+              type: object
+      responses:
+        201:
+          description: 'Prompt créé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PromptResource'
+        400:
+          description: 'Quota dépassé ou tarif manquant'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/socials/search:
+    get:
+      tags:
+        - Socials
+      summary: 'Lister les posts sociaux selon des critères'
+      description: "Retourne la liste des posts sociaux selon les critères fournis pour l'utilisateur connecté. Les admins voient tous les posts."
+      operationId: 7a007528f8f8ecf0237c246c02a8bfb4
+      parameters:
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par ID utilisateur (automatiquement ajouté si non admin)'
+          required: false
+          schema:
+            type: integer
+            example: 12
+      responses:
+        200:
+          description: 'Liste des posts sociaux'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SocialResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/api/socials/{id}':
+    get:
+      tags:
+        - Socials
+      summary: 'Afficher un post social'
+      description: "Retourne les détails d'un post social spécifique."
+      operationId: adbd7036008d50a4d5a182865df231d8
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post social'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Détails du post social'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SocialResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Post social non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      tags:
+        - Socials
+      summary: 'Mettre à jour un post social'
+      description: 'Met à jour un post social existant.'
+      operationId: cdcb69617f13f45a38d87cce27b255ae
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post social'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'Nom du post social mis à jour'
+              type: object
+      responses:
+        200:
+          description: 'Post social mis à jour'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SocialResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Post social non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - Socials
+      summary: 'Supprimer un post social'
+      description: 'Supprime un post social existant.'
+      operationId: 9f991c53862c609d0a559b7bb76404a1
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post social'
+          required: true
+          schema:
+            type: integer
+            example: 7
+      responses:
+        200:
+          description: 'Post social supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        404:
+          description: 'Post social non trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/socials:
+    get:
+      tags:
+        - Socials
+      summary: 'Lister tous les posts sociaux'
+      description: 'Retourne tous les posts sociaux.'
+      operationId: cd9d4c0f5aac27bfb759d24983c98b71
+      responses:
+        200:
+          description: 'Liste des posts sociaux'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SocialResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - Socials
+      summary: 'Créer un post social'
+      description: 'Crée un nouveau post social.'
+      operationId: 969ba7a236e8870adf58669eb6403063
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'Nom du post social'
+              type: object
+      responses:
+        201:
+          description: 'Post social créé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SocialResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        422:
+          description: 'Validation échouée'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/social-posts:
+    get:
+      tags:
+        - SocialPosts
+      summary: 'Lister les posts sociaux selon des critères'
+      description: 'Retourne les posts sociaux filtrés selon les critères fournis. Les utilisateurs non-admins ne verront que leurs propres posts.'
+      operationId: 2757608aeb538ad693d3999b04a43cfa
+      parameters:
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par ID utilisateur (optionnel, seulement pour admins)'
+          required: false
+          schema:
+            type: integer
+            example: 5
+        -
+          name: campaign_id
+          in: query
+          description: 'Filtrer par ID de campagne (optionnel)'
+          required: false
+          schema:
+            type: integer
+            example: 3
+        -
+          name: social_id
+          in: query
+          description: 'Filtrer par ID social (optionnel)'
+          required: false
+          schema:
+            type: integer
+            example: 2
+      responses:
+        200:
+          description: 'Liste des posts sociaux filtrés'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SocialPostResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 12
+                    type: object
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Non authentifié'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: "Vous n'avez pas la permission d'accéder à cette ressource"
+                type: object
+        404:
+          description: 'Ressource non trouvée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Aucun post social trouvé'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Erreur interne du serveur'
+                type: object
+    post:
+      tags:
+        - SocialPosts
+      summary: 'Créer un post social'
+      description: "Créer un nouveau post social à partir d'un prompt et d'une campagne"
+      operationId: 61b1e9171d85173dc3262bb3d1087600
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                content:
+                  type: string
+                  example: 'Contenu du post'
+                prompt_id:
+                  type: integer
+                  example: 1
+                social_id:
+                  type: integer
+                  example: 2
+                campaign_id:
+                  type: integer
+                  example: 3
+                is_published:
+                  type: boolean
+                  example: true
+              type: object
+      responses:
+        200:
+          description: 'Post créé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SocialPostResource'
+        422:
+          description: 'Erreur de validation ou contenu invalide'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  type:
+                    type: string
+                    example: no_content
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Accès refusé'
+                type: object
+  '/api/social-posts/{id}':
+    get:
+      tags:
+        - SocialPosts
+      summary: 'Afficher un post social'
+      description: 'Retourne un post social par son ID'
+      operationId: 97dff84626481df517763d496e559eb6
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post social'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Post social trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SocialPostResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Non authentifié'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Accès refusé'
+                type: object
+        404:
+          description: 'Post non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Post social non trouvé'
+                type: object
+    put:
+      tags:
+        - SocialPosts
+      summary: 'Mettre à jour un post social'
+      description: 'Met à jour un post social existant'
+      operationId: 57402d6bb5fc6fa5d615bde43cfb0c06
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post social à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                content:
+                  type: string
+                  example: 'Contenu mis à jour'
+                is_published:
+                  type: boolean
+                  example: false
+              type: object
+      responses:
+        200:
+          description: 'Post mis à jour'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SocialPostResource'
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Accès refusé'
+                type: object
+        404:
+          description: 'Post non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Post social non trouvé'
+                type: object
+    delete:
+      tags:
+        - SocialPosts
+      summary: 'Supprimer un post social'
+      description: 'Supprime un post social par ID'
+      operationId: 0fa49b416cc5c1bec242f0f91d8955d7
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post social à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Post supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Accès refusé'
+                type: object
+        404:
+          description: 'Post non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Post social non trouvé'
+                type: object
+  /api/social-posts/index:
+    get:
+      tags:
+        - SocialPosts
+      summary: 'Lister tous les posts sociaux'
+      description: "Retourne tous les posts sociaux. Les autorisations sont respectées selon le rôle de l'utilisateur."
+      operationId: 9b6992af489ab3f8d3d25e2b6d01bf21
+      responses:
+        200:
+          description: 'Liste des posts sociaux'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SocialPostResource'
+                  meta:
+                    properties:
+                      total:
+                        type: integer
+                        example: 12
+                    type: object
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Non authentifié'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Accès refusé'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Erreur interne du serveur'
+                type: object
+  '/api/social-posts/{id}/regenerate':
+    post:
+      tags:
+        - SocialPosts
+      summary: 'Régénérer un post social'
+      description: "Régénère le contenu d'un post social existant"
+      operationId: 273c68e92ae5210abc5d6ceb1a2c58a5
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du post à régénérer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                content:
+                  type: string
+                  example: 'Nouveau contenu régénéré'
+              type: object
+      responses:
+        200:
+          description: 'Post régénéré avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Post régénéré avec succès'
+                  data:
+                    type: object
+                type: object
+        422:
+          description: 'Aucun contenu généré'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  type:
+                    type: string
+                    example: no_content
+                type: object
+        500:
+          description: 'Erreur interne de régénération'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Erreur lors de la régénération'
+                  type:
+                    type: string
+                    example: regeneration_error
+                type: object
+  /api/social-posts/generate:
+    post:
+      tags:
+        - SocialPosts
+      summary: 'Générer des posts pour plusieurs plateformes'
+      description: "Génère et crée des posts sur plusieurs plateformes à partir d'un topic, campagne et prompt"
+      operationId: 9038dc778b77bdf83e177594f7edcf86
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                topic:
+                  type: string
+                  example: 'Nouvelle campagne'
+                platforms:
+                  type: array
+                  items:
+                    type: string
+                    enum:
+                      - linkedin
+                      - x
+                      - tiktok
+                campaign_id:
+                  type: integer
+                  example: 1
+                prompt_id:
+                  type: integer
+                  example: 1
+                tone:
+                  type: string
+                  example: friendly
+                language:
+                  type: string
+                  example: french
+                hashtags:
+                  type: string
+                  example: '#marketing'
+                target_audience:
+                  type: string
+                  example: 'professionnels du marketing'
+                is_published:
+                  type: boolean
+                  example: true
+              type: object
+      responses:
+        200:
+          description: 'Posts générés avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  generated:
+                    type: boolean
+                    example: true
+                  posts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SocialPostResource'
+                  count:
+                    type: integer
+                    example: 3
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Erreur de validation'
+                type: object
+        500:
+          description: 'Erreur serveur lors de la génération'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Failed to generate posts'
+                  error:
+                    type: string
+                    example: 'Exception message'
+                type: object
+  '/api/suggestions/{userId}':
+    get:
+      tags:
+        - Suggestions
+      summary: 'Récupérer les suggestions pour un utilisateur'
+      description: "Renvoie la liste des suggestions pour l'utilisateur authentifié"
+      operationId: 2e6f05e8e19a11ebc3773cd7d204845a
+      parameters:
+        -
+          name: userId
+          in: path
+          description: "ID de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Suggestions récupérées avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  suggestions:
+                    type: array
+                    items:
+                      properties:
+                        id:
+                          type: integer
+                          example: 1
+                        title:
+                          type: string
+                          example: 'Titre de la suggestion'
+                        description:
+                          type: string
+                          example: 'Description détaillée'
+                        created_at:
+                          type: string
+                          format: date-time
+                          example: '2025-09-25 10:00:00'
+                      type: object
+                type: object
+        500:
+          description: 'Erreur serveur lors de la récupération des suggestions'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la récupération des suggestions.'
+                type: object
+  /api/tarifs/search:
+    get:
+      tags:
+        - Tarifs
+      summary: 'Lister les tarifs selon des critères'
+      description: 'Retourne une liste de tarifs filtrés selon les critères passés en query parameters.'
+      operationId: 1e3f036bcea82342683c82ab5b350f34
+      parameters:
+        -
+          name: name
+          in: query
+          description: 'Filtrer par nom du tarif'
+          required: false
+          schema:
+            type: string
+        -
+          name: amount
+          in: query
+          description: 'Filtrer par montant'
+          required: false
+          schema:
+            type: number
+            format: float
+      responses:
+        200:
+          description: 'Liste des tarifs récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TarifResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+  '/api/tarifs/{id}':
+    get:
+      tags:
+        - Tarifs
+      summary: 'Afficher un tarif'
+      description: 'Récupère les informations d’un tarif spécifique par ID'
+      operationId: ece726a5b51d4dd5a09dd262bdcdfdda
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du tarif'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Détails du tarif'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'Tarif non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Tarif introuvable.'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+    put:
+      tags:
+        - Tarifs
+      summary: 'Mettre à jour un tarif'
+      description: 'Met à jour les informations d’un tarif existant'
+      operationId: 8f27f369337d937ffa022efa39fae0d6
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du tarif à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - amount
+                - max_limit
+              properties:
+                name:
+                  type: string
+                  example: 'Tarif Standard'
+                amount:
+                  type: number
+                  format: float
+                  example: 29.99
+                max_limit:
+                  type: integer
+                  example: 50
+              type: object
+      responses:
+        200:
+          description: 'Tarif mis à jour avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'Tarif non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Tarif introuvable.'
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'The given data was invalid.'
+                  errors:
+                    type: object
+                    example:
+                      amount:
+                        - 'Le champ amount doit être un nombre.'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+    delete:
+      tags:
+        - Tarifs
+      summary: 'Supprimer un tarif'
+      description: 'Supprime un tarif existant par son identifiant'
+      operationId: 980701f7033035e8328af7dcb8efc567
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du tarif à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Tarif supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'Tarif non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Tarif introuvable.'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+  /api/tarifs:
+    get:
+      tags:
+        - Tarifs
+      summary: 'Lister tous les tarifs'
+      description: 'Récupère la liste complète des tarifs disponibles'
+      operationId: 4586fdd2682253d9b7d71bb73ea5ff37
+      responses:
+        200:
+          description: 'Liste des tarifs'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TarifResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+    post:
+      tags:
+        - Tarifs
+      summary: 'Créer un tarif'
+      description: 'Crée un nouveau tarif avec les données fournies'
+      operationId: 0efd316450ea82501b29eda5cfac27db
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - amount
+                - max_limit
+              properties:
+                name:
+                  type: string
+                  example: 'Tarif Premium'
+                amount:
+                  type: number
+                  format: float
+                  example: 49.99
+                max_limit:
+                  type: integer
+                  example: 100
+              type: object
+      responses:
+        200:
+          description: 'Tarif créé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifResource'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'The given data was invalid.'
+                  errors:
+                    type: object
+                    example:
+                      name:
+                        - 'Le champ name est obligatoire.'
+                type: object
+        500:
+          description: 'Erreur interne du serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+  '/api/tarif-features/{id}':
+    get:
+      tags:
+        - 'Tarif Features'
+      summary: 'Récupérer un TarifFeature par ID'
+      description: "Retourne les détails d'une caractéristique de tarif spécifique."
+      operationId: 82ecf452d2dfc0c38cf288ec2c22b03e
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TarifFeature'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Détails du TarifFeature'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifFeatureResource'
+        404:
+          description: 'TarifFeature non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'TarifFeature not found'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+    put:
+      tags:
+        - 'Tarif Features'
+      summary: 'Mettre à jour une caractéristique de tarif'
+      description: "Met à jour le nom ou le tarif associé d'une feature existante."
+      operationId: b6f6ab503010633d4a5038732b07724f
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TarifFeature'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: 'Support Premium 24/7'
+              type: object
+      responses:
+        200:
+          description: 'TarifFeature mis à jour'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifFeatureResource'
+        404:
+          description: 'TarifFeature non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'TarifFeature not found'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+    delete:
+      tags:
+        - 'Tarif Features'
+      summary: 'Supprimer une caractéristique de tarif'
+      description: 'Supprime une feature existante par son ID.'
+      operationId: b037634a6273f04e6ffa2f1839618801
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TarifFeature à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'Feature supprimée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        404:
+          description: 'Feature non trouvée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'TarifFeature not found'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+  /api/tarif-features:
+    get:
+      tags:
+        - 'Tarif Features'
+      summary: 'Récupérer tous les TarifFeatures'
+      description: 'Retourne la liste complète des caractéristiques de tarifs.'
+      operationId: 75470fc7b052d939bb1c31d7fd4bf611
+      responses:
+        200:
+          description: 'Liste complète des TarifFeatures'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifFeatureCollection'
+        401:
+          description: 'Non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+    post:
+      tags:
+        - 'Tarif Features'
+      summary: 'Créer une nouvelle caractéristique de tarif'
+      description: 'Crée un TarifFeature pour un tarif donné.'
+      operationId: eec3b58a83a41cacb95e487e683012b6
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - tarif_id
+                - name
+              properties:
+                tarif_id:
+                  type: integer
+                  example: 2
+                name:
+                  type: string
+                  example: 'Support 24/7'
+              type: object
+      responses:
+        201:
+          description: 'TarifFeature créé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifFeatureResource'
+        400:
+          description: 'Données invalides'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Validation failed'
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+  /api/tarif-users/search:
+    get:
+      tags:
+        - TarifUsers
+      summary: 'Récupérer les TarifUsers selon des critères'
+      description: "Retourne une collection de TarifUser filtrée selon les critères fournis. Si l'utilisateur n'est pas admin, seuls ses propres enregistrements sont renvoyés."
+      operationId: 8cc4cd9f346b0323fe91edd88202c3dd
+      parameters:
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par user_id (optionnel, non admin ignoré)'
+          required: false
+          schema:
+            type: integer
+            example: 1
+        -
+          name: tarif_id
+          in: query
+          description: 'Filtrer par tarif_id (optionnel)'
+          required: false
+          schema:
+            type: integer
+            example: 2
+      responses:
+        200:
+          description: 'Collection de TarifUser renvoyée avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifUserCollection'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la récupération des données'
+                type: object
+  '/api/tarif-users/{id}':
+    get:
+      tags:
+        - TarifUsers
+      summary: 'Afficher un TarifUser'
+      description: "Retourne les détails d'un TarifUser par ID"
+      operationId: da4e9c848e97ba49f577187d31df795d
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TarifUser'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'TarifUser renvoyé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifUserResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'TarifUser non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+    put:
+      tags:
+        - TarifUsers
+      summary: 'Mettre à jour un TarifUser'
+      description: "Met à jour les informations d'un TarifUser existant"
+      operationId: abeb9c036d85b4e4bb0e2ecbd488026d
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TarifUser à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                tarif_id:
+                  type: integer
+                  example: 2
+                expired_at:
+                  type: string
+                  format: date-time
+                  example: '2025-11-25 12:00'
+              type: object
+      responses:
+        200:
+          description: 'TarifUser mis à jour avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifUserResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'TarifUser non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Le tarif_id est requis'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la mise à jour'
+                type: object
+    delete:
+      tags:
+        - TarifUsers
+      summary: 'Supprimer un TarifUser'
+      description: 'Supprime un TarifUser par ID'
+      operationId: 3da9065f9f88da2326119292144684af
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TarifUser à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'TarifUser supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'TarifUser non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la suppression'
+                type: object
+  /api/tarif-users:
+    get:
+      tags:
+        - TarifUsers
+      summary: 'Récupérer les TarifUsers selon des critères'
+      description: "Retourne une collection de TarifUser filtrée selon les critères fournis. Si l'utilisateur n'est pas admin, seuls ses propres enregistrements sont renvoyés."
+      operationId: 66e34f8edf0679e484748e7ea951091e
+      parameters:
+        -
+          name: user_id
+          in: query
+          description: 'Filtrer par user_id (optionnel, non admin ignoré)'
+          required: false
+          schema:
+            type: integer
+            example: 1
+        -
+          name: tarif_id
+          in: query
+          description: 'Filtrer par tarif_id (optionnel)'
+          required: false
+          schema:
+            type: integer
+            example: 2
+      responses:
+        200:
+          description: 'Collection de TarifUser renvoyée avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifUserCollection'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la récupération des données'
+                type: object
+    post:
+      tags:
+        - TarifUsers
+      summary: 'Créer un nouveau TarifUser'
+      description: 'Crée un TarifUser pour un utilisateur'
+      operationId: ff98bd9615b3e44c39c18f820beb0c18
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - tarif_id
+                - user_id
+              properties:
+                tarif_id:
+                  type: integer
+                  example: 2
+                user_id:
+                  type: integer
+                  example: 5
+                expired_at:
+                  type: string
+                  format: date-time
+                  example: '2025-10-25 12:00'
+              type: object
+      responses:
+        201:
+          description: 'TarifUser créé avec succès'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TarifUserResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        422:
+          description: 'Erreur de validation'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Le tarif_id est requis'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la création'
+                type: object
+  '/api/tarif-users/latest/{userId}':
+    get:
+      tags:
+        - TarifUsers
+      summary: 'Récupérer le dernier TarifUser pour un utilisateur'
+      description: "Retourne le dernier TarifUser actif pour l'utilisateur spécifié. Si aucun tarif n'est trouvé, renvoie null."
+      operationId: 2507531ba3b17911a2243a25a2a6e49b
+      parameters:
+        -
+          name: userId
+          in: path
+          description: "ID de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 5
+      responses:
+        200:
+          description: 'Dernier TarifUser récupéré avec succès'
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  -
+                    $ref: '#/components/schemas/TarifUserResource'
+                  -
+                    properties:
+                      success:
+                        type: boolean
+                        example: true
+                      data:
+                        type: 'null'
+                        example: null
+                      message:
+                        type: string
+                        example: 'Aucun tarif trouvé pour cet utilisateur.'
+                    type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'Utilisateur non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la récupération du dernier tarif'
+                type: object
+  /api/type-campaigns/search:
+    get:
+      tags:
+        - TypeCampaigns
+      summary: 'Récupère les TypeCampaign selon des critères'
+      description: "Retourne une liste de TypeCampaign filtrée selon les critères passés en query. Si l'utilisateur n'est pas admin, filtrage automatique par user_id."
+      operationId: 9f86e07f74b8fab16e46a5bb3b510716
+      parameters:
+        -
+          name: name
+          in: query
+          description: 'Filtre par nom du type de campagne'
+          required: false
+          schema:
+            type: string
+            example: Marketing
+      responses:
+        200:
+          description: 'Liste des TypeCampaign récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TypeCampaignResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la récupération des TypeCampaign'
+                type: object
+  '/api/type-campaigns/{id}':
+    get:
+      tags:
+        - TypeCampaigns
+      summary: 'Afficher un TypeCampaign'
+      description: 'Récupère un TypeCampaign par son ID.'
+      operationId: 0528947cd25210f43d23183cd249bd08
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TypeCampaign'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'TypeCampaign trouvé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypeCampaignResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'TypeCampaign non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+    put:
+      tags:
+        - TypeCampaigns
+      summary: 'Mettre à jour un TypeCampaign'
+      description: 'Met à jour un TypeCampaign existant.'
+      operationId: 4c80365b14dbd95361f9332854c78489
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TypeCampaign à mettre à jour'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'Nouvelle campagne marketing'
+              type: object
+      responses:
+        200:
+          description: 'TypeCampaign mis à jour'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypeCampaignResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'TypeCampaign non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+        422:
+          description: 'Données invalides'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Le nom est requis'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+    delete:
+      tags:
+        - TypeCampaigns
+      summary: 'Supprime un TypeCampaign'
+      description: 'Supprime un TypeCampaign existant par son ID. Nécessite les droits de suppression.'
+      operationId: 1e9fda4143b6a998196a760881e16ebc
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID du TypeCampaign à supprimer'
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 'TypeCampaign supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Supprimé avec succès.'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        404:
+          description: 'TypeCampaign non trouvé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Not Found'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue lors de la suppression du TypeCampaign'
+                type: object
+  /api/type-campaigns:
+    get:
+      tags:
+        - TypeCampaigns
+      summary: 'Liste tous les TypeCampaign'
+      description: 'Récupère tous les TypeCampaign pour les utilisateurs autorisés.'
+      operationId: a83015b7330b4f0745c73526fdcb20e1
+      responses:
+        200:
+          description: 'Liste des TypeCampaign'
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/TypeCampaignResource'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+    post:
+      tags:
+        - TypeCampaigns
+      summary: 'Créer un TypeCampaign'
+      description: 'Crée un nouveau TypeCampaign.'
+      operationId: b6f2726a1fe0d1d8ae53e37d283eebb1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'Campagne marketing'
+              type: object
+      responses:
+        201:
+          description: 'TypeCampaign créé'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypeCampaignResource'
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Accès refusé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        422:
+          description: 'Données invalides'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Le nom est requis'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+  /api/user/change-password:
+    post:
+      tags:
+        - User
+      summary: "Changer le mot de passe d'un utilisateur authentifié"
+      description: "Permet à l'utilisateur connecté de changer son mot de passe en fournissant l'ancien et le nouveau mot de passe."
+      operationId: 90caeaca9052218c3b4f1eed102e1da8
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - currentPassword
+                - newPassword
+                - newPassword_confirmation
+              properties:
+                currentPassword:
+                  type: string
+                  example: ancienMotDePasse123
+                newPassword:
+                  type: string
+                  example: nouveauMotDePasse123
+                newPassword_confirmation:
+                  type: string
+                  example: nouveauMotDePasse123
+              type: object
+      responses:
+        200:
+          description: 'Mot de passe modifié avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Mot de passe modifié avec succès.'
+                type: object
+        400:
+          description: 'Erreur lors du changement de mot de passe'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Mot de passe actuel incorrect.'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        422:
+          description: 'Données invalides ou confirmation du mot de passe échouée'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Le champ newPassword doit être confirmé.'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue'
+                type: object
+  '/api/user/{id}':
+    delete:
+      tags:
+        - User
+      summary: 'Supprimer un utilisateur'
+      description: "Supprime un utilisateur spécifié par son ID. L'utilisateur authentifié ne peut pas se supprimer lui-même."
+      operationId: 08d4c8edcd7de080c6128a966dcce4c1
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'utilisateur à supprimer"
+          required: true
+          schema:
+            type: integer
+            example: 5
+      responses:
+        200:
+          description: 'Utilisateur supprimé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Utilisateur supprimé avec succès.'
+                type: object
+        400:
+          description: 'Tentative de suppression de son propre compte'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Vous ne pouvez pas supprimer votre propre compte.'
+                type: object
+        401:
+          description: 'Utilisateur non authentifié'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Unauthorized
+                type: object
+        403:
+          description: 'Utilisateur non autorisé à effectuer cette action'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: Forbidden
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: "Une erreur est survenue lors de la suppression de l'utilisateur."
+                type: object
+  /api/users:
+    get:
+      tags:
+        - User
+      summary: 'Lister les utilisateurs'
+      description: 'Récupère une liste paginée des utilisateurs. Possibilité de filtrer par rôle et vérification email, et de trier par colonnes.'
+      operationId: c208f5a9f57878cd2aa19b1a470f91cf
+      parameters:
+        -
+          name: role
+          in: query
+          description: 'Filtrer par rôle'
+          required: false
+          schema:
+            type: string
+            example: admin
+        -
+          name: verified
+          in: query
+          description: 'Filtrer par utilisateurs vérifiés (true/false)'
+          required: false
+          schema:
+            type: boolean
+            example: true
+        -
+          name: sort_by
+          in: query
+          description: 'Colonne de tri'
+          required: false
+          schema:
+            type: string
+            example: created_at
+        -
+          name: sort_order
+          in: query
+          description: 'Ordre de tri'
+          required: false
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+            example: desc
+        -
+          name: per_page
+          in: query
+          description: "Nombre d'utilisateurs par page"
+          required: false
+          schema:
+            type: integer
+            example: 15
+      responses:
+        200:
+          description: 'Liste des utilisateurs récupérée avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UserResource'
+                type: object
+        403:
+          description: 'Accès non autorisé'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: false
+                  message:
+                    type: string
+                    example: 'Accès non autorisé.'
+                type: object
+        500:
+          description: 'Erreur serveur'
+          content:
+            application/json:
+              schema:
+                properties:
+                  message:
+                    type: string
+                    example: 'Une erreur est survenue.'
+                type: object
+    post:
+      tags:
+        - Users
+      summary: 'Créer un utilisateur'
+      description: 'Crée un nouvel utilisateur'
+      operationId: UserStore
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'John Doe'
+                email:
+                  type: string
+                  example: john@example.com
+                password:
+                  type: string
+                  example: secret123
+                role:
+                  type: string
+                  enum:
+                    - user
+                    - admin
+                  example: user
+              type: object
+      responses:
+        201:
+          description: 'Utilisateur créé avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Utilisateur créé avec succès.'
+                  data:
+                    $ref: '#/components/schemas/UserResource'
+                type: object
+        400:
+          description: 'Données invalides ou erreur'
+        401:
+          description: 'Non authentifié'
+        403:
+          description: 'Accès non autorisé'
+        500:
+          description: 'Erreur interne du serveur'
+  '/api/users/{id}':
+    get:
+      tags:
+        - Users
+      summary: 'Afficher un utilisateur'
+      description: "Récupère les informations d'un utilisateur spécifique"
+      operationId: UserShow
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: Succès
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    $ref: '#/components/schemas/UserResource'
+                type: object
+        401:
+          description: 'Non authentifié'
+        403:
+          description: 'Accès non autorisé'
+        500:
+          description: 'Erreur interne du serveur'
+    put:
+      tags:
+        - Users
+      summary: 'Mettre à jour un utilisateur'
+      description: "Met à jour les informations d'un utilisateur existant"
+      operationId: UserUpdate
+      parameters:
+        -
+          name: id
+          in: path
+          description: "ID de l'utilisateur"
+          required: true
+          schema:
+            type: integer
+            example: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'John Doe'
+                email:
+                  type: string
+                  example: john@example.com
+                password:
+                  type: string
+                  example: secret123
+                role:
+                  type: string
+                  enum:
+                    - user
+                    - admin
+                  example: user
+              type: object
+      responses:
+        200:
+          description: 'Utilisateur mis à jour avec succès'
+          content:
+            application/json:
+              schema:
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  message:
+                    type: string
+                    example: 'Utilisateur mis à jour avec succès.'
+                  data:
+                    $ref: '#/components/schemas/UserResource'
+                type: object
+        400:
+          description: 'Données invalides'
+        401:
+          description: 'Non authentifié'
+        403:
+          description: 'Accès non autorisé'
+        500:
+          description: 'Erreur interne du serveur'
+components:
+  schemas:
+    CampaignResource:
+      title: 'Campaign Resource'
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'Campagne de test'
+        user_id:
+          type: integer
+          example: 10
+        type_campaign_id:
+          type: integer
+          example: 3
+        status:
+          properties:
+            value:
+              type: string
+              example: active
+            label:
+              type: string
+              example: Active
+          type: object
+        is_published:
+          type: boolean
+          example: true
+        description:
+          type: string
+          example: 'Description de la campagne'
+        user:
+          properties:
+            id:
+              type: integer
+              example: 10
+            name:
+              type: string
+              example: 'Jean Dupont'
+          type: object
+          nullable: true
+        user_has_liked:
+          type: boolean
+          example: true
+        user_has_shared:
+          type: boolean
+          example: false
+        type:
+          properties:
+            id:
+              type: integer
+              example: 2
+            name:
+              type: string
+              example: 'Campagne Marketing'
+          type: object
+          nullable: true
+        dates:
+          properties:
+            created_at:
+              type: string
+              example: '2025-09-21 12:00'
+            updated_at:
+              type: string
+              example: '2025-09-21 12:30'
+            time_ago:
+              type: string
+              example: 'il y a 2 heures'
+          type: object
+        images_count:
+          type: integer
+          example: 3
+        landing_pages_count:
+          type: integer
+          example: 1
+        social_posts_count:
+          type: integer
+          example: 5
+        total_views:
+          type: integer
+          example: 1000
+        total_likes:
+          type: integer
+          example: 50
+        total_shares:
+          type: integer
+          example: 20
+        images:
+          type: array
+          items:
+            properties:
+              id:
+                type: integer
+                example: 1
+              url:
+                type: string
+                example: 'https://cdn.site.com/image1.jpg'
+              alt:
+                type: string
+                example: 'Image de la campagne'
+              is_published:
+                type: boolean
+                example: true
+              created_at:
+                type: string
+                example: '2025-09-21 12:15'
+            type: object
+      type: object
+    PopularCampaignResourceSchema:
+      title: 'Popular Campaign Resource'
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'Campagne populaire'
+        description:
+          type: string
+          example: 'Description de la campagne'
+        type_campaign_id:
+          type: integer
+          example: 2
+        image_path:
+          type: string
+          example: 'https://cdn.site.com/image1.jpg'
+        total_views:
+          type: integer
+          example: 1200
+        total_likes:
+          type: integer
+          example: 150
+      type: object
+    CampaignFeaturesResource:
+      title: 'Campaign Features Resource'
+      properties:
+        id:
+          type: integer
+          example: 1
+        campaign_id:
+          type: integer
+          example: 10
+        feature_id:
+          type: integer
+          example: 3
+      type: object
+    CampaignInteractionResource:
+      title: 'Campaign Interaction'
+      description: "Représentation d'une interaction utilisateur avec une campagne"
+      properties:
+        id:
+          type: integer
+          example: 101
+        campaign_id:
+          description: 'Identifiant de la campagne'
+          type: integer
+          example: 12
+        user_id:
+          description: 'Identifiant de l’utilisateur ayant interagi'
+          type: integer
+          example: 45
+        type:
+          description: 'Type d’interaction (view, like, share…)'
+          type: string
+          example: like
+        views:
+          description: 'Nombre de vues associées'
+          type: integer
+          example: 5
+        likes:
+          description: 'Nombre de likes associés'
+          type: integer
+          example: 1
+        shares:
+          description: 'Nombre de partages associés'
+          type: integer
+          example: 0
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25T12:34:56Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25T14:12:00Z'
+      type: object
+    CampaignInteractionMeta:
+      title: 'Campaign Interaction Meta'
+      description: "Métadonnées globales sur les interactions d'une campagne"
+      properties:
+        total_interactions:
+          description: 'Nombre total d’interactions'
+          type: integer
+          example: 50
+        total_views:
+          description: 'Nombre total de vues'
+          type: integer
+          example: 120
+        total_likes:
+          description: 'Nombre total de likes'
+          type: integer
+          example: 30
+        total_shares:
+          description: 'Nombre total de partages'
+          type: integer
+          example: 10
+      type: object
+    CampaignTemplateResource:
+      title: 'Campaign Template'
+      description: "Représentation d'un modèle de campagne avec ses stats et informations détaillées"
+      properties:
+        id:
+          description: 'Identifiant du template'
+          type: integer
+          example: 7
+        name:
+          description: 'Nom du template'
+          type: string
+          example: 'Template Marketing Automatique'
+        description:
+          description: 'Description du template'
+          type: string
+          example: 'Template pour campagne marketing automatisée'
+        category:
+          properties:
+            id:
+              type: integer
+              example: 2
+            name:
+              type: string
+              example: Marketing
+            icon:
+              type: string
+              example: marketing-icon
+          type: object
+          nullable: true
+        type:
+          properties:
+            id:
+              type: integer
+              example: 1
+            name:
+              type: string
+              example: 'Email Campaign'
+          type: object
+          nullable: true
+        author:
+          description: 'Auteur du template'
+          type: string
+          example: 'John Doe'
+        thumbnail:
+          description: 'URL de la miniature du template'
+          type: string
+          example: 'https://example.com/thumbnails/template7.png'
+        preview:
+          description: "URL de l'aperçu du template"
+          type: string
+          example: 'https://example.com/previews/template7.png'
+        isPremium:
+          description: 'Indique si le template est premium'
+          type: boolean
+          example: true
+        rating:
+          description: 'Note moyenne du template'
+          type: number
+          format: float
+          example: 4.5
+        uses:
+          description: 'Nombre de fois que le template a été utilisé'
+          type: integer
+          example: 120
+        tags:
+          description: 'Tags associés au template'
+          type: array
+          items:
+            type: string
+          example:
+            - marketing
+            - automation
+            - email
+        socialPosts:
+          type: array
+          items:
+            properties:
+              id:
+                type: integer
+                example: 101
+              content:
+                type: string
+                example: 'Découvrez notre nouveau produit !'
+              created_at:
+                type: string
+                format: date-time
+                example: '2025-09-25 12:34'
+              social:
+                properties:
+                  id:
+                    type: integer
+                    example: 3
+                  name:
+                    type: string
+                    example: LinkedIn
+                type: object
+                nullable: true
+            type: object
+        createdAt:
+          description: 'Date de création du template'
+          type: string
+          format: date
+          example: '2025-09-01'
+      type: object
+    Error400:
+      title: 'Requête incorrecte'
+      description: 'Les paramètres de la requête sont invalides'
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Paramètres de requête invalides'
+      type: object
+    Error401:
+      title: 'Non authentifié'
+      description: 'Authentification requise ou token invalide'
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Authentification requise'
+      type: object
+    Error403:
+      title: 'Accès refusé'
+      description: 'Permissions insuffisantes'
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Accès non autorisé'
+      type: object
+    Error422:
+      title: 'Erreur de validation'
+      description: 'Données de validation invalides'
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Les données fournies sont invalides'
+        errors:
+          type: object
+          example:
+            email:
+              - 'Le champ email est obligatoire.'
+            password:
+              - 'Le mot de passe doit contenir au moins 8 caractères.'
+      type: object
+    Error500:
+      title: 'Erreur serveur'
+      description: 'Erreur interne du serveur'
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Erreur interne du serveur'
+      type: object
+    ErrorResponse:
+      title: 'Erreur générique'
+      description: "Structure de réponse en cas d'erreur"
+      properties:
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Une erreur est survenue'
+        errors:
+          description: 'Détails des erreurs de validation (optionnel)'
+          type: object
+          example:
+            email:
+              - 'Le champ email est obligatoire.'
+      type: object
+    FeatureResource:
+      title: 'Feature Resource'
+      description: "Représentation d'une fonctionnalité (Feature)"
+      properties:
+        id:
+          type: integer
+          example: 12
+        name:
+          type: string
+          example: 'Nouvelle Fonctionnalité'
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 15:30'
+      type: object
+    FeatureCollection:
+      title: 'Feature Collection'
+      description: 'Collection de fonctionnalités'
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureResource'
+      type: object
+    ImageResource:
+      title: 'Image Resource'
+      description: "Représentation d'une image"
+      properties:
+        id:
+          type: integer
+          example: 101
+        path:
+          type: string
+          example: /uploads/images/example.png
+        is_published:
+          type: boolean
+          example: true
+        campaign_id:
+          type: integer
+          example: 5
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25T15:30:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25T15:45:00Z'
+        prompt:
+          type: string
+          example: "Image générée à partir d'une IA"
+          nullable: true
+      type: object
+    ImageCollection:
+      title: 'Image Collection'
+      description: "Collection d'images avec métadonnées"
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImageResource'
+        meta:
+          properties:
+            total:
+              type: integer
+              example: 10
+          type: object
+      type: object
+    LandingPageResource:
+      title: 'Landing Page Resource'
+      description: "Représentation d'une landing page"
+      properties:
+        id:
+          type: integer
+          example: 7
+        content:
+          type: string
+          example: '<h1>Bienvenue</h1>'
+        campaign_id:
+          type: integer
+          example: 3
+        is_published:
+          type: boolean
+          example: true
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 15:30:00'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 16:00:00'
+      type: object
+    LandingPageCollection:
+      title: 'Landing Page Collection'
+      description: 'Collection de landing pages'
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/LandingPageResource'
+        meta:
+          properties:
+            total:
+              type: integer
+              example: 12
+          type: object
+      type: object
+    PromptResource:
+      properties:
+        id:
+          type: integer
+          example: 1
+        content:
+          type: string
+          example: 'Créer un prompt pour campagne X'
+        campaign_id:
+          type: integer
+          example: 5
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 15:30:00'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 15:30:00'
+      type: object
+    SocialResource:
+      title: 'Social Resource'
+      description: 'Représente un post social'
+      properties:
+        name:
+          type: string
+          example: 'Nom du post social'
+      type: object
+    SocialPostResource:
+      title: 'SocialPost Resource'
+      description: 'Représente un post social'
+      properties:
+        id:
+          type: integer
+          example: 1
+        content:
+          type: string
+          example: 'Contenu du post social'
+        is_published:
+          type: boolean
+          example: true
+        social_id:
+          type: integer
+          example: 2
+        campaign_id:
+          type: integer
+          example: 3
+        prompt_id:
+          type: integer
+          example: 4
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 12:34:56'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 12:34:56'
+        social:
+          description: 'Relation chargée du social'
+          type: object
+          example:
+            id: 2
+            name: 'Nom du social'
+          nullable: true
+        campaign:
+          description: 'Relation chargée de la campagne'
+          type: object
+          example:
+            id: 3
+            title: 'Nom de la campagne'
+          nullable: true
+      type: object
+    TarifResource:
+      description: 'Représente un tarif'
+      properties:
+        id:
+          description: 'ID du tarif'
+          type: integer
+          example: 1
+        name:
+          description: 'Nom du tarif'
+          type: string
+          example: Pro
+        amount:
+          description: 'Montant du tarif'
+          type: number
+          format: float
+          example: 29.99
+        max_limit:
+          description: 'Limite maximale associée au tarif'
+          type: integer
+          example: 50
+      type: object
+    TarifFeatureResource:
+      title: 'Tarif Feature'
+      description: "Représentation d'une fonctionnalité liée à un tarif"
+      properties:
+        id:
+          type: integer
+          example: 1
+        tarif_id:
+          type: integer
+          example: 5
+        name:
+          type: string
+          example: 'Support Premium'
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 12:30'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 12:30'
+      type: object
+    TarifFeatureCollection:
+      title: 'Tarif Feature Collection'
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/TarifFeatureResource'
+      type: object
+    TarifUserCollection:
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/TarifUserResource'
+      type: object
+    TarifUserResource:
+      title: TarifUser
+      description: "Représentation d'un TarifUser"
+      properties:
+        id:
+          type: integer
+          example: 1
+        tarif_id:
+          type: integer
+          example: 2
+        user_id:
+          type: integer
+          example: 5
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 12:00'
+        expired_at:
+          type: string
+          format: date-time
+          example: '2025-10-25 12:00'
+        tarif:
+          properties:
+            id:
+              type: integer
+              example: 2
+            name:
+              type: string
+              example: Premium
+            amount:
+              type: number
+              format: float
+              example: 99.99
+            max_limit:
+              type: integer
+              example: 100
+          type: object
+      type: object
+    TypeCampaignResource:
+      title: TypeCampaignResource
+      description: "Représentation d'un TypeCampaign"
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Marketing
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 14:30'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-25 14:30'
+      type: object
+    User:
+      title: User
+      description: "Représentation d'un utilisateur"
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'John Doe'
+        email:
+          type: string
+          format: email
+          example: john.doe@example.com
+        role:
+          type: string
+          example: user
+        email_verified_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      type: object
+    UserResource:
+      title: 'User Resource'
+      description: "Représentation d'un utilisateur"
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'John Doe'
+        email:
+          type: string
+          example: john@example.com
+        role:
+          type: string
+          example: admin
+        email_verified_at:
+          type: string
+          format: date-time
+          example: '2025-09-25T19:00:00Z'
+        created_at:
+          type: string
+          format: date-time
+          example: '2025-09-01T12:00:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          example: '2025-09-20T10:00:00Z'
+      type: object
+  securitySchemes:
+    sanctum:
+      type: apiKey
+      description: 'Enter token in format (Bearer <token>)'
+      name: Authorization
+      in: header
+tags:
+  -
+    name: Authentication
+    description: Authentication
+  -
+    name: Campaigns
+    description: Campaigns
+  -
+    name: CampaignFeatures
+    description: CampaignFeatures
+  -
+    name: 'Campaign Interactions'
+    description: 'Campaign Interactions'
+  -
+    name: 'Campaign Templates'
+    description: 'Campaign Templates'
+  -
+    name: Dashboard
+    description: Dashboard
+  -
+    name: 'Email Verification'
+    description: 'Email Verification'
+  -
+    name: Features
+    description: Features
+  -
+    name: Images
+    description: Images
+  -
+    name: LandingPages
+    description: LandingPages
+  -
+    name: Payments
+    description: Payments
+  -
+    name: PasswordReset
+    description: PasswordReset
+  -
+    name: Prompts
+    description: Prompts
+  -
+    name: Socials
+    description: Socials
+  -
+    name: SocialPosts
+    description: SocialPosts
+  -
+    name: Suggestions
+    description: Suggestions
+  -
+    name: Tarifs
+    description: Tarifs
+  -
+    name: 'Tarif Features'
+    description: 'Tarif Features'
+  -
+    name: TarifUsers
+    description: TarifUsers
+  -
+    name: TypeCampaigns
+    description: TypeCampaigns
+  -
+    name: User
+    description: User
+  -
+    name: Users
+    description: Users
+security:
+  -
+    sanctum: []

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $documentationTitle }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        const urls = [];
+
+        @foreach($urlsToDocs as $title => $url)
+            urls.push({name: "{{ $title }}", url: "{{ $url }}"});
+        @endforeach
+
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            urls: urls,
+            "urls.primaryName": "{{ $documentationTitle }}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
- Intégration de L5 Swagger pour générer la documentation de l'API REST.
- Configuration de la génération automatique des fichiers YAML dans 'docs'.
 - Ajout des annotations dans les contrôleurs openAPI pour décrire les endpoints.
- Ajout des annotations dans les contrôleurs pour décrire les endpoints.

Utilisation :
- Lancer `php artisan l5-swagger:generate` pour regénérer la documentation.
- Modifier les annotations dans les contrôleurs openAPI pour tenir à jour la doc.